### PR TITLE
PDFFix: normalize PDF probability by totalSimSecs (Issue #56)

### DIFF
--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -499,8 +499,9 @@ def createPDFCache(config):
     _saveSummaryDS(config, cacheDF, 'PDFCache')
     logger.info(f"PDF cache: {len(cacheDF)} rows for site {config['siteName']}")
 
+    totalSimSecs = config['simDurationDays'] * 86400.0 * config['monteCarloIterations']
     with Timer("Build PDFs") as tPDF:
-        fullPDFDF, noFugPDFDF, pdfStatsDF = calculatePDFSummaryFromCache(cacheDF)
+        fullPDFDF, noFugPDFDF, pdfStatsDF = calculatePDFSummaryFromCache(cacheDF, totalSimSecs)
         fullPDFDF = fullPDFDF.assign(includeFugitive=True)
         noFugPDFDF = noFugPDFDF.assign(includeFugitive=False)
         pdfDF = pd.concat([fullPDFDF, noFugPDFDF])
@@ -530,7 +531,7 @@ def _buildMCRunTimeseries(mcRunDF):
         t.setCount(len(emitterTSList))
     return result
 
-def _buildPDFForGroup(groupDF, identityCols, CICategory):
+def _buildPDFForGroup(groupDF, identityCols, CICategory, totalSimSecs):
     with Timer("build MC run timeseries") as t:
         mcRunTSList = []
         for _, mcRunDF in groupDF.groupby('mcRun'):
@@ -553,24 +554,23 @@ def _buildPDFForGroup(groupDF, identityCols, CICategory):
     if cdf.isempty():
         return None, stats
     n = len(cdf.data)
-    totalCount = pdf.data['count'].sum()
     pdfRows = pd.DataFrame({
         **{col: [val] * n for col, val in identityCols.items()},
         'CICategory': [CICategory] * n,
         'emissionRate_kgPerH': cdf.data['value'].values,
-        'probability': (pdf.data['count'] / totalCount).values,
+        'probability': (pdf.data['count'] / totalSimSecs).values,
         'cumulativeProbability': cdf.data['cumulative_probability'].values,
     })
     return pdfRows, stats
 
-def calculatePDFSummary(instEmissionDF):
+def calculatePDFSummary(instEmissionDF, totalSimSecs):
     instEmissionDF = _removeZeroEmissionEvents(instEmissionDF)
     resultDFList = []
     statsList = []
     for CICategory, groupCols in PDF_GROUPINGS:
         for _, groupDF in instEmissionDF.groupby(groupCols):
             identityCols = {col: groupDF[col].iloc[0] for col in groupCols}
-            pdfRows, stats = _buildPDFForGroup(groupDF, identityCols, CICategory)
+            pdfRows, stats = _buildPDFForGroup(groupDF, identityCols, CICategory, totalSimSecs)
             statsList.append(stats)
             if pdfRows is not None:
                 resultDFList.append(pdfRows)
@@ -580,7 +580,7 @@ def calculatePDFSummary(instEmissionDF):
 
 VALIDATE_QUANTILES = [0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
 
-def _makePDFRows(mcRunTSList, identityCols, CICategory):
+def _makePDFRows(mcRunTSList, identityCols, CICategory, totalSimSecs):
     if not mcRunTSList:
         return None
     pdf = ts.TimeseriesSet(mcRunTSList).toPDF()
@@ -588,16 +588,15 @@ def _makePDFRows(mcRunTSList, identityCols, CICategory):
     if cdf.isempty():
         return None
     n = len(cdf.data)
-    totalCount = pdf.data['count'].sum()
     return pd.DataFrame({
         **{col: [val] * n for col, val in identityCols.items()},
         'CICategory': [CICategory] * n,
         'emissionRate_kgPerH': cdf.data['value'].values,
-        'probability': (pdf.data['count'] / totalCount).values,
+        'probability': (pdf.data['count'] / totalSimSecs).values,
         'cumulativeProbability': cdf.data['cumulative_probability'].values,
     })
 
-def _buildPDFForGroupFromCache(groupDF, identityCols, CICategory):
+def _buildPDFForGroupFromCache(groupDF, identityCols, CICategory, totalSimSecs):
     fullMCRunTSList = []
     noFugMCRunTSList = []
     with Timer("build MC run timeseries from coarse cache", loglevel=logging.DEBUG) as t:
@@ -621,9 +620,9 @@ def _buildPDFForGroupFromCache(groupDF, identityCols, CICategory):
         'mcRunCount': len(fullMCRunTSList),
         'buildSeconds': t.deltat.total_seconds(),
     }
-    return _makePDFRows(fullMCRunTSList, identityCols, CICategory), _makePDFRows(noFugMCRunTSList, identityCols, CICategory), stats
+    return _makePDFRows(fullMCRunTSList, identityCols, CICategory, totalSimSecs), _makePDFRows(noFugMCRunTSList, identityCols, CICategory, totalSimSecs), stats
 
-def calculatePDFSummaryFromCache(cacheDF, groupings=None):
+def calculatePDFSummaryFromCache(cacheDF, totalSimSecs, groupings=None):
     if groupings is None:
         groupings = PDF_GROUPINGS
     fullResultDFList = []
@@ -633,7 +632,7 @@ def calculatePDFSummaryFromCache(cacheDF, groupings=None):
         levelDF = cacheDF[cacheDF['cacheLevel'] == CICategory]
         for _, groupDF in levelDF.groupby(groupCols):
             identityCols = {col: groupDF[col].iloc[0] for col in groupCols}
-            fullPDFRows, noFugPDFRows, stats = _buildPDFForGroupFromCache(groupDF, identityCols, CICategory)
+            fullPDFRows, noFugPDFRows, stats = _buildPDFForGroupFromCache(groupDF, identityCols, CICategory, totalSimSecs)
             statsList.append(stats)
             if fullPDFRows is not None:
                 fullResultDFList.append(fullPDFRows)
@@ -679,8 +678,9 @@ def validatePDFCache(config):
     logger.info(f"Intermediate check: {len(sampleIdx)} groups sampled, {mismatchCount} mismatches")
 
     # End-to-end check: compare CDFs from raw-instEmissions path vs cache path at fixed quantile points
-    pdfFromRaw, _ = calculatePDFSummary(instEmissionDF)
-    pdfFromCache, _, _ = calculatePDFSummaryFromCache(cacheDF)
+    totalSimSecs = config['simDurationDays'] * 86400.0 * config['monteCarloIterations']
+    pdfFromRaw, _ = calculatePDFSummary(instEmissionDF, totalSimSecs)
+    pdfFromCache, _, _ = calculatePDFSummaryFromCache(cacheDF, totalSimSecs)
 
     joinCols = [c for c in pdfFromRaw.columns if c not in ('emissionRate_kgPerH', 'probability', 'cumulativeProbability')]
     rawSampled = _sampleCDFAtQuantiles(pdfFromRaw, joinCols)

--- a/src/UnitTests/test_Summaries2.py
+++ b/src/UnitTests/test_Summaries2.py
@@ -1,0 +1,163 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import unittest
+import numpy as np
+import pandas as pd
+import Timeseries as ts
+from Summaries2 import _makePDFRows, _buildPDFForGroupFromCache
+
+
+def _makeSparseRLE(activeSecs: float, rateKgPerH: float) -> ts.TimeseriesRLE:
+    """Build a single-interval RLE timeseries starting at t=0."""
+    return ts.TimeseriesRLE.fromCollections(
+        np.array([0.0]),
+        np.array([activeSecs]),
+        np.array([rateKgPerH]),
+    )
+
+
+IDENTITY = {'site': 'TestSite', 'species': 'METHANE', 'operator': 'OP', 'psno': 'PS1',
+            'METype': 'Equipment', 'unitID': 'U1', 'modelReadableName': 'Blowdown Event',
+            'modelEmissionCategory': 'EQUIPMENT'}
+
+
+class TestMakePDFRowsProbabilityNormalization(unittest.TestCase):
+
+    def test_probSumsToActiveFractionNotOne(self):
+        """Probability sum must equal active_secs/totalSimSecs, not 1.0.
+
+        This is the core regression for the blowdown/start-event PDF bug:
+        before the fix, totalCount used pdf.data['count'].sum() (active seconds
+        only), so probability always summed to 1.0 regardless of duty cycle.
+        """
+        activeSecs = 10.0
+        totalSimSecs = 100.0
+        rle = _makeSparseRLE(activeSecs, rateKgPerH=5.0)
+        rows = _makePDFRows([rle], IDENTITY, 'modelReadableName', totalSimSecs)
+        self.assertIsNotNone(rows)
+        probSum = rows['probability'].sum()
+        self.assertAlmostEqual(probSum, activeSecs / totalSimSecs, places=10)
+
+    def test_probSumNotOneForSparseEmitter(self):
+        """Probability must not sum to 1.0 for an emitter active only 10% of sim time."""
+        rle = _makeSparseRLE(activeSecs=10.0, rateKgPerH=5.0)
+        rows = _makePDFRows([rle], IDENTITY, 'modelReadableName', totalSimSecs=100.0)
+        self.assertIsNotNone(rows)
+        self.assertLess(rows['probability'].sum(), 1.0)
+
+    def test_probSumEqualsOneForAlwaysOnEmitter(self):
+        """Probability sums to 1.0 when emitter is active 100% of simulation."""
+        totalSimSecs = 100.0
+        rle = _makeSparseRLE(activeSecs=totalSimSecs, rateKgPerH=5.0)
+        rows = _makePDFRows([rle], IDENTITY, 'modelReadableName', totalSimSecs)
+        self.assertIsNotNone(rows)
+        self.assertAlmostEqual(rows['probability'].sum(), 1.0, places=10)
+
+    def test_probSumAcrossMultipleMCRuns(self):
+        """With N MC runs each active for fraction f, prob sum = f (not 1.0).
+
+        Each MC run: 20s active out of 100s. Two MC runs → totalSimSecs = 200s.
+        The blowdown emitter fires in both runs at the same rate, so the PDF
+        has one bin. Expected probability = 40/200 = 0.2.
+        """
+        activeSecs = 20.0
+        mcRuns = 2
+        totalSimSecs = 100.0 * mcRuns
+        rles = list(map(lambda _: _makeSparseRLE(activeSecs, rateKgPerH=5.0), range(mcRuns)))
+        rows = _makePDFRows(rles, IDENTITY, 'modelReadableName', totalSimSecs)
+        self.assertIsNotNone(rows)
+        self.assertAlmostEqual(rows['probability'].sum(), (activeSecs * mcRuns) / totalSimSecs, places=10)
+
+    def test_probSumWithMultipleRates(self):
+        """Multi-bin PDF: each bin's probability is its active_secs/totalSimSecs."""
+        totalSimSecs = 100.0
+        rle_low = ts.TimeseriesRLE.fromCollections(
+            np.array([0.0, 50.0]),
+            np.array([10.0, 60.0]),
+            np.array([2.0, 5.0]),
+        )
+        rows = _makePDFRows([rle_low], IDENTITY, 'modelReadableName', totalSimSecs)
+        self.assertIsNotNone(rows)
+        self.assertAlmostEqual(rows['probability'].sum(), 20.0 / totalSimSecs, places=10)
+
+    def test_emptyMCRunListReturnsNone(self):
+        """Empty MC run list must return None without raising."""
+        ret = _makePDFRows([], IDENTITY, 'modelReadableName', totalSimSecs=100.0)
+        self.assertIsNone(ret)
+
+    def test_blowdownLikeProbabilityIsSmall(self):
+        """Blowdown emitter active 0.1% of sim time → probability max ~0.001, not 1.0.
+
+        This directly reproduces the reported bug: Blowdown Event was returning
+        probability=1.0 for a single emission rate because zero idle time was
+        excluded from the denominator.
+        """
+        simDurationSecs = 365 * 24 * 3600.0
+        blowdownDurationSecs = simDurationSecs * 0.001
+        totalSimSecs = simDurationSecs * 10  # 10 MC runs
+        rles = list(map(
+            lambda _: _makeSparseRLE(blowdownDurationSecs, rateKgPerH=2815.52),
+            range(10),
+        ))
+        rows = _makePDFRows(rles, IDENTITY, 'modelReadableName', totalSimSecs)
+        self.assertIsNotNone(rows)
+        self.assertAlmostEqual(rows['probability'].sum(), 0.001, places=6)
+        self.assertLess(rows['probability'].max(), 0.01)
+
+
+class TestBuildPDFForGroupFromCacheProbabilityNormalization(unittest.TestCase):
+
+    def _makeCacheDF(self, mcRun: int, startTime: float, endTime: float,
+                     rateKgPerH: float) -> pd.DataFrame:
+        """Build a minimal PDFCache-format DataFrame for one MC run interval."""
+        return pd.DataFrame({
+            'site': ['TestSite'],
+            'species': ['METHANE'],
+            'operator': ['OP'],
+            'psno': ['PS1'],
+            'METype': ['Equipment'],
+            'unitID': ['U1'],
+            'modelReadableName': ['Blowdown Event'],
+            'modelEmissionCategory': ['EQUIPMENT'],
+            'mcRun': [mcRun],
+            'startTime_s': [startTime],
+            'endTime_s': [endTime],
+            'emission_kgPerH': [rateKgPerH],
+            'cacheLevel': ['modelReadableName'],
+        })
+
+    def test_cachePathProbSumsToActiveFraction(self):
+        """Cache-path PDF has the same correct normalization as the raw path."""
+        activeSecs = 10.0
+        totalSimSecs = 100.0
+        groupDF = self._makeCacheDF(mcRun=0, startTime=0.0, endTime=activeSecs, rateKgPerH=5.0)
+        identityCols = {
+            'site': 'TestSite', 'species': 'METHANE', 'operator': 'OP', 'psno': 'PS1',
+            'METype': 'Equipment', 'unitID': 'U1', 'modelReadableName': 'Blowdown Event',
+        }
+        fullRows, noFugRows, stats = _buildPDFForGroupFromCache(
+            groupDF, identityCols, 'modelReadableName', totalSimSecs)
+        self.assertIsNotNone(fullRows)
+        self.assertAlmostEqual(fullRows['probability'].sum(), activeSecs / totalSimSecs, places=10)
+
+    def test_fugitiveExclusionStillNormalizedCorrectly(self):
+        """noFug path: FUGITIVE rows excluded but denominator is still totalSimSecs."""
+        activeSecs = 10.0
+        totalSimSecs = 100.0
+        fugDF = self._makeCacheDF(mcRun=0, startTime=0.0, endTime=activeSecs, rateKgPerH=5.0)
+        fugDF = fugDF.assign(modelEmissionCategory='FUGITIVE')
+        identityCols = {
+            'site': 'TestSite', 'species': 'METHANE', 'operator': 'OP', 'psno': 'PS1',
+            'METype': 'Equipment', 'unitID': 'U1', 'modelReadableName': 'Blowdown Event',
+        }
+        fullRows, noFugRows, stats = _buildPDFForGroupFromCache(
+            fugDF, identityCols, 'modelReadableName', totalSimSecs)
+        self.assertIsNotNone(fullRows)
+        self.assertAlmostEqual(fullRows['probability'].sum(), activeSecs / totalSimSecs, places=10)
+        self.assertIsNone(noFugRows)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Single-commit fix (`691b2e1`) on top of Summary_Rewrite addressing Issue #56:

- PDF probability column in `Summaries.py` was computed as `count/active_count`, so transient emitters (Blowdown, Start events) always summed to 1.0 and produced inflated weighted emissions.
- Now computed as `count/totalSimSecs`, giving correct probability mass for short-lived event sources.
- Adds `test_Summaries2.py` (9 tests) covering the new normalization.

Closes #56.

## Why this PR targets Summary_Rewrite (not main)

Part of a consolidation strategy: Summary_Rewrite will be the single unified PR to main, carrying the Parquet rewrite, RNG_Consolidation, and PDFFix together. Downstream attention has been on Summary_Rewrite, so we're keeping all related fixes converging there.

## Diff scope

PDFFix is a linear extension of Summary_Rewrite (already contains the `53b4e97` backslash fix), so this is a **fast-forward merge**: a single commit, +/- in `src/Summaries.py` and a new test file.

## Test plan

- [ ] `pytest src/Testing/test_Summaries2.py` — 9 tests pass
- [ ] Full test suite still green on Summary_Rewrite after merge