### PR TITLE
Clip events at simulation-window boundary (issue #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 
 ## v0.4.0 (unreleased)
 
+### Bug Fixes (2026-05-26)
+
+- **Summaries2.py** — `_createEmissionDF`: clip events at the simulation-window boundary
+  (issue #87). The engine logs the full sampled `duration` of whatever state is in
+  progress when simpy stops at `simDurationSecs`, so `timestamp + duration` can exceed the
+  window. Left unclipped, the overrun added spurious emission credit past the window,
+  biasing every rate-integrated quantity (annual summaries, PDFs) upward — verified at
+  +67.8% on a real 41.5-day `Compressor Rod Packing Vent` overrun in `JennaBug2`.
+  `_createEmissionDF` now takes `simDurationSecs` and clips each event's `duration_s` to
+  `min(duration, simDurationSecs − timestamp)` (floored at 0), recomputing
+  `totalEmission_kg` from the clipped duration; `emission_kgPerS` (the rate) is unchanged.
+  This is the single point where the emission DataFrame is built and saved as
+  `InstEmissions` (the dataset the PDF cascade reads back), so the rate summaries, event
+  summaries, and PDFs are all consistent over `[0, simDurationSecs]`, restoring the
+  identity `mean_pdf = mean_events`. Note: `calculateEventSummary`'s `meanEventDuration_s`
+  / `totalEventDuration_s` now reflect in-window durations for overrunning events; the
+  full sampled durations remain available in the raw events parquet. Independent of the
+  additive `overrunSecs` / `underrunSecs` column proposal (#89).
+
+### Tests (2026-05-26)
+
+- **test/test_issue87_event_clipping.py**: new test file covering simulation-window event
+  clipping (issue #87). Asserts that overrunning events are clipped to the in-window
+  remainder with `totalEmission_kg` recomputed and the rate preserved; interior and
+  exactly-at-boundary events are untouched; an event starting past the window yields zero
+  (not negative) duration; `calculateAnnualSummaries` totals reflect only in-window
+  emission; and `_buildMCRunTimeseries` → PDF mean equals the rate-integrated mean over
+  `[0, T]` after clipping.
+
 ### Schema Changes (2026-03-31)
 
 - **defaultConfig.json** / **ParquetLib.py**: renamed the new Parquet summary directory

--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -57,7 +57,7 @@ def _convertKGPerYear2MetricTonsPerYear(x):
 def _convertKGPerYear2KGPerHour(x):
     return x * KG_PER_YEAR_TO_KG_PER_HOUR
 
-def _createEmissionDF(inDF):
+def _createEmissionDF(inDF, simDurationSecs):
     COLS_TO_KEEP = {'mcRun': 'mcRun',
                     'site': 'site',
                     'species': 'species',
@@ -79,8 +79,28 @@ def _createEmissionDF(inDF):
         psno=inDF['psno'].fillna('')
     )
 
+    # Issue #87: clip events that overrun the simulation window so every downstream
+    # consumer integrates emissions only over [0, simDurationSecs]. The engine logs the
+    # full sampled duration of whatever state is in progress when simpy stops at
+    # simDurationSecs, so `timestamp + duration` can exceed the window. Left unclipped,
+    # the overrun adds spurious emission credit past the window and biases all
+    # rate-integrated quantities (annual summaries, PDFs) upward for long / fat-tailed
+    # event classes. This is the single point where the emission DataFrame is built and
+    # saved as InstEmissions -- the dataset the PDF cascade reads back -- so clipping
+    # here keeps the rate summaries, the event summaries, and the PDFs mutually
+    # consistent over [0, simDurationSecs]. The raw events parquet retains the full
+    # sampled durations. The rate (emission_kgPerS) is unchanged; only duration_s and
+    # totalEmission_kg shrink, for the at-most-one in-progress event per emitter state
+    # machine whose end exceeds the window. `.clip(lower=0)` guards the degenerate case
+    # of an event timestamped at or after the window end (which the engine should not
+    # produce) from yielding a negative duration.
+    clippedDuration = np.minimum(
+        inDF['duration'],
+        (simDurationSecs - inDF['timestamp']).clip(lower=0)
+    )
     emissionDF = emissionDF.assign(
-        totalEmission_kg=emissionDF['emission_kgPerS']*emissionDF['duration'],
+        duration=clippedDuration,
+        totalEmission_kg=emissionDF['emission_kgPerS'] * clippedDuration,
     )
 
     emissionDF = emissionDF.rename(columns=COLS_TO_KEEP)
@@ -728,7 +748,7 @@ def summarizeSingleSite(config, instEmissionDF):
     mcIterations = config['monteCarloIterations']
     with Timer("summarize") as t0:
         simDurationDays = config['simDurationDays']
-        instEmissionDF = _createEmissionDF(instEmissionDF)
+        instEmissionDF = _createEmissionDF(instEmissionDF, simDurationDays * u.SECONDS_PER_DAY)
         _saveSummaryDS(config, instEmissionDF, 'InstEmissions')
         instEmissionNoFugitiveDF = instEmissionDF[instEmissionDF['modelEmissionCategory'] != 'FUGITIVE']
 

--- a/test/test_issue87_event_clipping.py
+++ b/test/test_issue87_event_clipping.py
@@ -1,0 +1,131 @@
+"""
+Regression tests for simulation-window event clipping (GitHub issue #87).
+
+The engine logs the full sampled `duration` of whatever state is in progress when
+simpy stops at `simDurationSecs`, so `timestamp + duration` can exceed the window.
+Left unclipped, this overrun adds spurious emission credit past the window and biases
+every rate-integrated quantity (annual summaries, PDFs) upward — by tens of percent
+for long / fat-tailed event classes (verified at +67.8% on a real 41.5-day overrun).
+
+The fix clips events at `_createEmissionDF` — the single point where the emission
+DataFrame is built and saved as InstEmissions (the dataset the PDF cascade reads
+back) — so the rate summaries, event summaries, and PDFs are all consistent over
+[0, simDurationSecs]. Only `emission_kgPerS` (the rate) is preserved; `duration_s`
+and `totalEmission_kg` shrink for the overrunning event.
+"""
+
+import numpy as np
+import pandas as pd
+
+import Units as u
+import Timeseries as ts
+from Summaries2 import _createEmissionDF, calculateAnnualSummaries, _buildMCRunTimeseries
+
+SIM_DURATION_DAYS = 365.0
+SIM_DURATION_SECS = SIM_DURATION_DAYS * u.SECONDS_PER_DAY  # 31_536_000
+
+RATE = 0.001  # kg/s
+
+
+def _raw_event(emitterID, timestamp, duration, rate=RATE, mc=0):
+    """One raw event row as readParquetEvents produces (pre-_createEmissionDF)."""
+    return {
+        'mcRun': mc, 'site': 'S1', 'species': 'METHANE',
+        'operator': 'op', 'psno': 'ps', 'emitterID': emitterID,
+        'timestamp': float(timestamp), 'duration': float(duration),
+        'emission': rate,
+        'METype': 'Compressor', 'unitID': 'U1',
+        'modelReadableName': 'CompressorComponentLeak',
+        'modelEmissionCategory': 'FUGITIVE',
+    }
+
+
+def test_overrunning_event_duration_clipped_to_window():
+    # interior event well inside the window; overrun event ends 100 days past T.
+    start = SIM_DURATION_SECS - 10 * u.SECONDS_PER_DAY      # starts 10 days before end
+    overrun_duration = 110 * u.SECONDS_PER_DAY              # would end 100 days past T
+    df = pd.DataFrame([
+        _raw_event('interior', timestamp=0, duration=3600.0),
+        _raw_event('overrun', timestamp=start, duration=overrun_duration),
+    ])
+    out = _createEmissionDF(df, SIM_DURATION_SECS).set_index('emitterID')
+
+    # interior event untouched
+    assert out.loc['interior', 'duration_s'] == 3600.0
+    assert abs(out.loc['interior', 'totalEmission_kg'] - RATE * 3600.0) < 1e-12
+
+    # overrun event clipped to exactly the in-window remainder
+    expected_dur = SIM_DURATION_SECS - start               # 10 days in seconds
+    assert abs(out.loc['overrun', 'duration_s'] - expected_dur) < 1e-9
+    # rate preserved, totalEmission recomputed from the clipped duration
+    assert out.loc['overrun', 'emission_kgPerS'] == RATE
+    assert abs(out.loc['overrun', 'totalEmission_kg'] - RATE * expected_dur) < 1e-9
+
+
+def test_event_ending_exactly_at_window_is_unchanged():
+    start = SIM_DURATION_SECS - 5 * u.SECONDS_PER_DAY
+    df = pd.DataFrame([_raw_event('edge', timestamp=start, duration=5 * u.SECONDS_PER_DAY)])
+    out = _createEmissionDF(df, SIM_DURATION_SECS).set_index('emitterID')
+    assert abs(out.loc['edge', 'duration_s'] - 5 * u.SECONDS_PER_DAY) < 1e-9
+
+
+def test_event_starting_after_window_yields_zero_duration_not_negative():
+    # The engine should not produce this, but guard against a negative duration.
+    df = pd.DataFrame([_raw_event('past', timestamp=SIM_DURATION_SECS + 100, duration=3600.0)])
+    out = _createEmissionDF(df, SIM_DURATION_SECS).set_index('emitterID')
+    assert out.loc['past', 'duration_s'] == 0.0
+    assert out.loc['past', 'totalEmission_kg'] == 0.0
+
+
+def test_annual_summary_uses_clipped_emission():
+    """The rate-integrated annual total reflects only in-window emission."""
+    start = SIM_DURATION_SECS - 10 * u.SECONDS_PER_DAY
+    df = pd.DataFrame([_raw_event('overrun', timestamp=start, duration=110 * u.SECONDS_PER_DAY)])
+    inst = _createEmissionDF(df, SIM_DURATION_SECS)
+
+    AGG = {
+        'total': ('emissions_kgPerYear', 'sum'),
+        'count': ('emissions_kgPerYear', 'count'),
+        'mean': ('emissions_kgPerYear', 'mean'),
+        'min': ('emissions_kgPerYear', 'min'),
+        'max': ('emissions_kgPerYear', 'max'),
+        'lowerQuartile': ('emissions_kgPerYear', lambda x: np.percentile(x, 25)),
+        'upperQuartile': ('emissions_kgPerYear', lambda x: np.percentile(x, 75)),
+        'lowerCI': ('emissions_kgPerYear', lambda x: np.percentile(x, 2.5)),
+        'upperCI': ('emissions_kgPerYear', lambda x: np.percentile(x, 97.5)),
+        'readings': ('emissions_kgPerYear', list),
+    }
+    summ = calculateAnnualSummaries(inst, SIM_DURATION_DAYS, AGG, mcIterations=1)
+
+    # in-window kg = rate * 10 days; annualized over a 365-day sim == itself.
+    in_window_kg = RATE * (10 * u.SECONDS_PER_DAY)
+    mrn = summ[summ['CICategory'] == 'modelReadableName']
+    site_total = mrn[mrn['modelReadableName'] == 'CompressorComponentLeak']['total'].iloc[0]
+    assert abs(site_total - in_window_kg) < 1e-6
+
+    # the unclipped total would have been rate * 110 days — guard against regression
+    unclipped_kg = RATE * (110 * u.SECONDS_PER_DAY)
+    assert site_total < 0.2 * unclipped_kg
+
+
+def test_pdf_mean_matches_rate_integrated_mean_after_clip():
+    """
+    The motivating identity from issue #89's second use-case bullet: feeding clipped
+    durations into _buildMCRunTimeseries restores mean_pdf == mean_events over [0,T].
+    Build one emitter's summed timeseries from clipped InstEmissions and confirm the
+    duration-weighted (PDF) mean rate equals total in-window emission / T.
+    """
+    start = SIM_DURATION_SECS - 10 * u.SECONDS_PER_DAY
+    df = pd.DataFrame([
+        _raw_event('e', timestamp=0, duration=3600.0),
+        _raw_event('e', timestamp=start, duration=110 * u.SECONDS_PER_DAY),
+    ])
+    inst = _createEmissionDF(df, SIM_DURATION_SECS)
+
+    ts_rle = _buildMCRunTimeseries(inst)
+    pdf = ts.TimeseriesSet([ts_rle]).toPDF()
+    pdf_mean = (pdf.data['value'] * (pdf.data['count'] / SIM_DURATION_SECS)).sum()  # kg/h
+
+    in_window_kg = RATE * (3600.0 + 10 * u.SECONDS_PER_DAY)
+    rate_mean = in_window_kg / SIM_DURATION_SECS * u.SECONDS_PER_HOUR  # kg/h
+    assert abs(pdf_mean - rate_mean) < 1e-9


### PR DESCRIPTION
## Issue #87 — event end times exceeding simulation duration

The engine logs the full sampled `duration` of whatever state is in progress when simpy stops at `simDurationSecs`, so `timestamp + duration` can exceed the window. Left unclipped, the overrun adds spurious emission credit past the window and biases every rate-integrated quantity (annual summaries, PDFs) **upward** — verified at **+67.8%** on a real 41.5-day `Compressor Rod Packing Vent` overrun in `JennaBug2`.

## Fix

`_createEmissionDF` now takes `simDurationSecs` and clips each event's `duration_s` to `min(duration, simDurationSecs − timestamp)` (floored at 0), recomputing `totalEmission_kg`; `emission_kgPerS` (the rate) is unchanged.

This is the **single point** where the emission DataFrame is built and saved as `InstEmissions` — the dataset the PDF cascade reads back — so the rate summaries, event summaries, and PDFs are all consistent over `[0, simDurationSecs]`, restoring the identity `mean_pdf = mean_events`. The raw events parquet retains the full sampled durations.

## Notes

- Per design discussion, **all** summarization/aggregation consumes clipped events; `calculateEventSummary`'s `meanEventDuration_s` therefore reflects in-window durations for overrunning events.
- Independent of the additive `overrunSecs`/`underrunSecs` column proposal (#89) — this is the interim engine-side clip.

## Verification

- Synthetic: old = 3× total, fixed = true total, both `includeFugitive` paths.
- Real data: `mean_pdf == mean_events` restored exactly (41.5-day overrun's +67.8% PDF-mean bias → 0%).
- New `test/test_issue87_event_clipping.py` (5 tests). Full maintained suite green (55 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)