### PR TITLE
Add directory-level Summary consistency checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@
     row (issue #77, a violation); per-site `siteTotals` PDF mean vs `SiteSummary`
     site-total mean (issue #74, reported as a **warning** because #74 is an open,
     unresolved discrepancy and the identity is not yet guaranteed). `simDurationSecs` is
-    read from the `simDurationDays` column; absent datasets are skipped.
+    read from the `simDurationDays` column; absent datasets are skipped. The `mean ≤ max`
+    / CI-bound comparisons use a small relative tolerance so a constant-rate emitter
+    (whose `mean = sum/N` can land ~1 ULP above the exact `max` from float64 rounding) is
+    not flagged as a spurious violation.
 
 ### Tests (2026-05-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 
 ## v0.4.0 (unreleased)
 
+### Validation (2026-05-27)
+
+- **Testing/SummaryConsistency.py**: new directory-level consistency checker for a MAES
+  `Summary/` parquet output. Unlike `SummaryTest.py` (new-vs-legacy comparison driven by a
+  scenario config), it operates on a directory alone and is unit-testable on synthetic
+  DataFrames. Two independently switchable tiers (`--structural` / `--cross-level` CLI
+  flags; `--rtol`, `--warn-rtol` tolerances; non-zero exit only on violations):
+  - **structural** — `InstEmissions`: timestamps/durations non-negative, events do not
+    overrun the simulation window (issue #87), emissions non-negative, `totalEmission_kg`
+    consistent with rate × duration; `SiteSummary`/`SimSummary`: `mean ≤ max` (violation),
+    CI-bound ordering (warning); `PDF`/`SimPDF`: probability non-negative, CDF monotone
+    and bounded by 1.
+  - **cross-level** — `SimSummary` rollup: `simulation` total equals the sum over each of
+    the modelReadableName / METype / unitID levels and the modelEmissionCategory COMBINED
+    row (issue #77, a violation); per-site `siteTotals` PDF mean vs `SiteSummary`
+    site-total mean (issue #74, reported as a **warning** because #74 is an open,
+    unresolved discrepancy and the identity is not yet guaranteed). `simDurationSecs` is
+    read from the `simDurationDays` column; absent datasets are skipped.
+
+### Tests (2026-05-27)
+
+- **test/test_summary_consistency.py**: new test file covering `SummaryConsistency.py`.
+  Each check is exercised on a clean fixture (no violations) and an injected fault flagged
+  at the correct severity — including a fixture mirroring the issue #77 triple-count
+  (`simulation` = 3 × level totals) and confirmation that the issue #74 PDF-vs-summary
+  mismatch is a warning, never a hard violation.
+
 ### Schema Changes (2026-03-31)
 
 - **defaultConfig.json** / **ParquetLib.py**: renamed the new Parquet summary directory

--- a/src/Testing/SummaryConsistency.py
+++ b/src/Testing/SummaryConsistency.py
@@ -1,0 +1,333 @@
+"""
+SummaryConsistency.py — directory-level consistency checks for a MAES Summary/ output.
+
+Given a `Summary/` parquet directory (the output of the `summarize` / `simSummary`
+phases), run a battery of cheap invariant checks and report violations. Unlike
+`SummaryTest.py` (which compares new-vs-legacy output and needs a scenario config),
+this operates on a directory alone and is unit-testable on synthetic DataFrames.
+
+Two tiers, independently switchable:
+
+* structural — per-dataset invariants that must hold for any correct output:
+    - InstEmissions: timestamps/durations non-negative, events do not overrun the
+      simulation window (issue #87), emissions non-negative, totalEmission_kg
+      consistent with rate x duration.
+    - SiteSummary / SimSummary: mean <= max (violation); lowerCI <= mean <= upperCI
+      (warning — can be valid for heavily right-skewed distributions, matching
+      SummaryTest.checkSimSummaryConsistency).
+    - PDF / SimPDF: probability non-negative, CDF monotone non-decreasing and
+      bounded by 1.
+
+* cross-level — relationships between aggregation levels:
+    - SimSummary rollup: the `simulation` total equals the sum over each of the
+      modelReadableName / METype / unitID levels, and the modelEmissionCategory
+      COMBINED row (issue #77). A hard violation.
+    - PDF-vs-summary mean: per-site `siteTotals` PDF mean vs the SiteSummary
+      site-total mean (issue #74). Reported as a WARNING, not a violation: #74 is
+      an open, unresolved discrepancy, so this identity is not yet guaranteed to
+      hold even on otherwise-correct output.
+
+CLI:
+    python SummaryConsistency.py <Summary dir> [--structural/--no-structural]
+        [--cross-level/--no-cross-level] [--rtol 1e-6] [--warn-rtol 0.05]
+Exit status is non-zero if any *violation* (not warning) is found.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+
+import Units as u
+
+logger = logging.getLogger(__name__)
+
+# Datasets we know how to read from a Summary/ directory.
+PARTITIONED = {'InstEmissions', 'SiteSummary', 'PDF'}        # hive-partitioned by site
+UNPARTITIONED = {'SimSummary', 'SimPDF'}                     # single dataset
+ALL_DATASETS = sorted(PARTITIONED | UNPARTITIONED)
+
+RATIO_SPECIES = 'C2/C1'      # min/max/CI are NaN by design; excluded from bounds checks
+EMISSION_SPECIES = ('METHANE', 'ETHANE')
+EMISSION_UNITS = ('kg/year', 'mt/year', 'US tons/year')
+
+# value columns of a PDF/CDF row — everything else identifies the distribution
+PDF_VALUE_COLS = ('emissionRate_kgPerH', 'probability', 'cumulativeProbability')
+
+
+@dataclass
+class CheckResult:
+    check: str
+    dataset: str
+    severity: str          # 'violation' | 'warning'
+    count: int             # number of offending rows / groups
+    total: int             # population examined
+    detail: str = ''
+
+    @property
+    def ok(self):
+        return self.count == 0
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def load_summary_dir(path):
+    """Read whichever known datasets are present under `path`. Returns a dict
+    {datasetName: DataFrame}; absent datasets are simply omitted."""
+    dfs = {}
+    for name in ALL_DATASETS:
+        ds_path = os.path.join(path, name)
+        if os.path.isdir(ds_path):
+            dfs[name] = pd.read_parquet(ds_path)
+    return dfs
+
+
+def sim_duration_secs(dfs):
+    """Pull simDurationSecs from the simDurationDays column of whichever summary
+    dataset carries it. Returns None if unavailable."""
+    for name in ('SiteSummary', 'SimSummary'):
+        df = dfs.get(name)
+        if df is not None and 'simDurationDays' in df.columns:
+            days = df['simDurationDays'].dropna().unique()
+            if len(days):
+                return float(days[0]) * u.SECONDS_PER_DAY
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Structural checks
+# ---------------------------------------------------------------------------
+
+def check_instemissions(ieDF, simDurationSecs, rtol=1e-6):
+    results = []
+    n = len(ieDF)
+
+    def _v(check, mask, detail=''):
+        results.append(CheckResult(check, 'InstEmissions', 'violation', int(mask.sum()), n, detail))
+
+    _v('timestamp_nonneg', ieDF['timestamp_s'] < 0)
+    _v('duration_nonneg', ieDF['duration_s'] < 0)
+    _v('emission_nonneg', ieDF['emission_kgPerS'] < 0)
+
+    if simDurationSecs is not None:
+        end = ieDF['timestamp_s'] + ieDF['duration_s']
+        over = end > simDurationSecs + 1e-6
+        worst = (end.max() - simDurationSecs) / u.SECONDS_PER_DAY if len(ieDF) else 0.0
+        _v('event_end_within_window', over,
+           f'simDurationSecs={simDurationSecs:.0f}; worst overrun={worst:.1f} days' if over.any() else '')
+    else:
+        results.append(CheckResult('event_end_within_window', 'InstEmissions', 'warning', 0, n,
+                                   'skipped — simDurationSecs unavailable'))
+
+    expected = ieDF['emission_kgPerS'] * ieDF['duration_s']
+    inconsistent = ~np.isclose(ieDF['totalEmission_kg'], expected, rtol=rtol, atol=1e-12)
+    _v('totalEmission_consistent', inconsistent)
+    return results
+
+
+def check_summary_bounds(df, dataset):
+    """mean <= max is a hard invariant (mean is the average of the readings, bounded
+    by their max). CI-bound ordering is a warning — valid for skewed distributions
+    with extreme MC outliers (see SummaryTest.checkSimSummaryConsistency)."""
+    required = ['species', 'mean', 'max', 'lowerCI', 'upperCI']
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        return [CheckResult('summary_bounds', dataset, 'warning', 0, len(df),
+                            f'skipped — missing columns {missing}')]
+    checkDF = df[df['species'] != RATIO_SPECIES]
+    n = len(checkDF)
+    results = [
+        CheckResult('mean_le_max', dataset, 'violation',
+                    int((checkDF['mean'] > checkDF['max']).sum()), n),
+        CheckResult('lowerCI_le_mean', dataset, 'warning',
+                    int((checkDF['lowerCI'] > checkDF['mean']).sum()), n),
+        CheckResult('mean_le_upperCI', dataset, 'warning',
+                    int((checkDF['mean'] > checkDF['upperCI']).sum()), n),
+    ]
+    return results
+
+
+def check_pdf_structural(df, dataset, tol=1e-9):
+    """probability >= 0, CDF monotone non-decreasing, CDF bounded by 1. These hold
+    for both the per-site PDF (whose probabilities sum to <1, the missing mass being
+    P(rate=0)) and the SimPDF mixture, so sum-to-1 is intentionally not asserted here."""
+    n = len(df)
+    neg_prob = int((df['probability'] < -tol).sum())
+
+    idCols = [c for c in df.columns if c not in PDF_VALUE_COLS]
+    nonmonotone = 0
+    overshoot = 0
+    groups = 0
+    for _, g in df.groupby(idCols, dropna=False):
+        groups += 1
+        g = g.sort_values('emissionRate_kgPerH')
+        cp = g['cumulativeProbability'].values
+        if np.any(np.diff(cp) < -tol):
+            nonmonotone += 1
+        if cp.size and cp.max() > 1.0 + 1e-6:
+            overshoot += 1
+
+    return [
+        CheckResult('probability_nonneg', dataset, 'violation', neg_prob, n),
+        CheckResult('cdf_monotone', dataset, 'violation', nonmonotone, groups),
+        CheckResult('cdf_bounded_by_1', dataset, 'violation', overshoot, groups),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Cross-level checks
+# ---------------------------------------------------------------------------
+
+def check_simsummary_rollup(simDF, rtol=1e-6):
+    """The simulation-wide total must equal the sum over each aggregation level
+    (issue #77). For each (species, units, includeFugitive) emission combination,
+    compare sum(mean) at the simulation level against modelReadableName / METype /
+    unitID rollups and the modelEmissionCategory COMBINED row."""
+    results = []
+    df = simDF[(simDF['species'].isin(EMISSION_SPECIES)) & (simDF['units'].isin(EMISSION_UNITS))]
+    keys = ['species', 'units', 'includeFugitive']
+
+    def level_total(sub, cic):
+        return sub[sub['CICategory'] == cic]['mean'].sum()
+
+    mismatches = {lvl: 0 for lvl in ('modelReadableName', 'METype', 'unitID', 'modelEmissionCategory')}
+    examples = []
+    combos = 0
+    for keyvals, sub in df.groupby(keys, dropna=False):
+        sim = level_total(sub, 'simulation')
+        if sim == 0:
+            continue
+        combos += 1
+        ref = max(abs(sim), 1e-12)
+        for lvl in ('modelReadableName', 'METype', 'unitID'):
+            lt = level_total(sub, lvl)
+            if abs(lt - sim) > rtol * ref:
+                mismatches[lvl] += 1
+                if len(examples) < 5:
+                    examples.append(f'{dict(zip(keys, keyvals if isinstance(keyvals, tuple) else (keyvals,)))}: '
+                                    f'sim={sim:.4f} {lvl}={lt:.4f}')
+        # modelEmissionCategory: the COMBINED row is the all-categories total
+        mec = sub[(sub['CICategory'] == 'modelEmissionCategory') & (sub.get('modelEmissionCategory') == 'COMBINED')]
+        combined = mec['mean'].sum()
+        if abs(combined - sim) > rtol * ref:
+            mismatches['modelEmissionCategory'] += 1
+
+    for lvl, cnt in mismatches.items():
+        results.append(CheckResult(f'simulation_eq_{lvl}', 'SimSummary', 'violation', cnt, combos,
+                                   '; '.join(examples) if cnt and lvl == 'modelReadableName' else ''))
+    return results
+
+
+def check_pdf_vs_summary_mean(pdfDF, siteDF, warn_rtol=0.05):
+    """Per-site siteTotals PDF mean vs SiteSummary site-total (COMBINED) mean
+    (issue #74). WARNING only — #74 is an open, unresolved discrepancy, so this
+    identity is not yet a guaranteed invariant."""
+    if 'includeFugitive' not in pdfDF.columns or 'site' not in pdfDF.columns:
+        return [CheckResult('pdf_mean_eq_summary_mean', 'PDF', 'warning', 0, 0,
+                            'skipped — PDF lacks site/includeFugitive columns')]
+    pdf = pdfDF[pdfDF['CICategory'] == 'siteTotals']
+    keys = ['site', 'species', 'includeFugitive']
+    mismatches = 0
+    compared = 0
+    examples = []
+    for keyvals, g in pdf.groupby(keys, dropna=False):
+        site, species, fug = keyvals
+        pdf_mean = (g['emissionRate_kgPerH'] * g['probability']).sum()  # kg/h
+        m = ((siteDF['site'] == site) & (siteDF['species'] == species)
+             & (siteDF['includeFugitive'] == fug)
+             & (siteDF['CICategory'] == 'modelEmissionCategory')
+             & (siteDF['modelEmissionCategory'] == 'COMBINED')
+             & (siteDF['units'] == 'kg/year'))
+        summary_kgyr = siteDF[m]['mean'].sum()
+        if summary_kgyr == 0:
+            continue
+        summary_kgh = summary_kgyr / u.HOURS_PER_YEAR
+        compared += 1
+        rel = abs(pdf_mean - summary_kgh) / max(abs(summary_kgh), 1e-12)
+        if rel > warn_rtol:
+            mismatches += 1
+            if len(examples) < 5:
+                examples.append(f'{site}/{species}/fug={fug}: pdf={pdf_mean:.4f} summary={summary_kgh:.4f} '
+                                f'({100*rel:.1f}%)')
+    return [CheckResult('pdf_mean_eq_summary_mean', 'PDF', 'warning', mismatches, compared,
+                        '; '.join(examples))]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def run_checks(dfs, structural=True, cross_level=True, rtol=1e-6, warn_rtol=0.05):
+    results = []
+    T = sim_duration_secs(dfs)
+
+    if structural:
+        if 'InstEmissions' in dfs:
+            results += check_instemissions(dfs['InstEmissions'], T, rtol=rtol)
+        for name in ('SiteSummary', 'SimSummary'):
+            if name in dfs:
+                results += check_summary_bounds(dfs[name], name)
+        for name in ('PDF', 'SimPDF'):
+            if name in dfs:
+                results += check_pdf_structural(dfs[name], name)
+
+    if cross_level:
+        if 'SimSummary' in dfs:
+            results += check_simsummary_rollup(dfs['SimSummary'], rtol=rtol)
+        if 'PDF' in dfs and 'SiteSummary' in dfs:
+            results += check_pdf_vs_summary_mean(dfs['PDF'], dfs['SiteSummary'], warn_rtol=warn_rtol)
+
+    return results
+
+
+def check_summary_dir(path, **kwargs):
+    return run_checks(load_summary_dir(path), **kwargs)
+
+
+def format_results(results):
+    lines = []
+    for r in results:
+        status = 'OK' if r.ok else ('VIOLATION' if r.severity == 'violation' else 'WARNING')
+        line = f'  [{status:9}] {r.dataset}/{r.check}: {r.count}/{r.total}'
+        if r.detail:
+            line += f'  ({r.detail})'
+        lines.append(line)
+    return '\n'.join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Consistency checks for a MAES Summary/ parquet directory.')
+    parser.add_argument('path', help='Path to the Summary/ directory')
+    parser.add_argument('--structural', action=argparse.BooleanOptionalAction, default=True,
+                        help='Run per-dataset structural invariant checks (default: on)')
+    parser.add_argument('--cross-level', dest='cross_level', action=argparse.BooleanOptionalAction, default=True,
+                        help='Run cross-level rollup / PDF-vs-summary checks (default: on)')
+    parser.add_argument('--rtol', type=float, default=1e-6, help='Relative tolerance for hard invariants')
+    parser.add_argument('--warn-rtol', type=float, default=0.05,
+                        help='Relative tolerance for the #74 PDF-vs-summary warning')
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    results = check_summary_dir(args.path, structural=args.structural, cross_level=args.cross_level,
+                                rtol=args.rtol, warn_rtol=args.warn_rtol)
+    if not results:
+        logging.info(f'No known datasets found under {args.path}')
+        return 0
+
+    logging.info(f'Consistency checks for {args.path}:')
+    logging.info(format_results(results))
+
+    violations = sum(r.count for r in results if r.severity == 'violation')
+    warnings = sum(r.count for r in results if r.severity == 'warning')
+    logging.info(f'\n{violations} violation(s), {warnings} warning(s).')
+    return 1 if violations else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/Testing/SummaryConsistency.py
+++ b/src/Testing/SummaryConsistency.py
@@ -131,10 +131,15 @@ def check_instemissions(ieDF, simDurationSecs, rtol=1e-6):
     return results
 
 
-def check_summary_bounds(df, dataset):
+def check_summary_bounds(df, dataset, rtol=1e-9, atol=1e-12):
     """mean <= max is a hard invariant (mean is the average of the readings, bounded
     by their max). CI-bound ordering is a warning — valid for skewed distributions
-    with extreme MC outliers (see SummaryTest.checkSimSummaryConsistency)."""
+    with extreme MC outliers (see SummaryTest.checkSimSummaryConsistency).
+
+    Comparisons use a small relative tolerance: for a constant-rate emitter every
+    reading is identical, so mean = sum/N can land ~1 ULP (~1e-16 relative) above the
+    exact max purely from float64 rounding. Without the tolerance those rows would be
+    flagged as spurious mean>max violations."""
     required = ['species', 'mean', 'max', 'lowerCI', 'upperCI']
     missing = [c for c in required if c not in df.columns]
     if missing:
@@ -142,13 +147,18 @@ def check_summary_bounds(df, dataset):
                             f'skipped — missing columns {missing}')]
     checkDF = df[df['species'] != RATIO_SPECIES]
     n = len(checkDF)
+
+    def _exceeds(a, b):
+        # a > b beyond a relative+absolute tolerance; NaN comparisons yield False
+        return (a - b) > (rtol * b.abs() + atol)
+
     results = [
         CheckResult('mean_le_max', dataset, 'violation',
-                    int((checkDF['mean'] > checkDF['max']).sum()), n),
+                    int(_exceeds(checkDF['mean'], checkDF['max']).sum()), n),
         CheckResult('lowerCI_le_mean', dataset, 'warning',
-                    int((checkDF['lowerCI'] > checkDF['mean']).sum()), n),
+                    int(_exceeds(checkDF['lowerCI'], checkDF['mean']).sum()), n),
         CheckResult('mean_le_upperCI', dataset, 'warning',
-                    int((checkDF['mean'] > checkDF['upperCI']).sum()), n),
+                    int(_exceeds(checkDF['mean'], checkDF['upperCI']).sum()), n),
     ]
     return results
 
@@ -272,7 +282,7 @@ def run_checks(dfs, structural=True, cross_level=True, rtol=1e-6, warn_rtol=0.05
             results += check_instemissions(dfs['InstEmissions'], T, rtol=rtol)
         for name in ('SiteSummary', 'SimSummary'):
             if name in dfs:
-                results += check_summary_bounds(dfs[name], name)
+                results += check_summary_bounds(dfs[name], name, rtol=rtol)
         for name in ('PDF', 'SimPDF'):
             if name in dfs:
                 results += check_pdf_structural(dfs[name], name)

--- a/test/test_summary_consistency.py
+++ b/test/test_summary_consistency.py
@@ -98,6 +98,25 @@ def test_summary_mean_gt_max_is_violation():
     assert res[('SimSummary', 'mean_le_max')].severity == 'violation'
 
 
+def test_summary_ulp_mean_over_max_not_flagged():
+    """Constant-rate emitter: mean = sum/N can land ~1 ULP above max from float64
+    rounding (all 388 real JennaBug2 mean>max rows were this). Must not be a violation."""
+    val = 2815.516539
+    mean_ulp = np.nextafter(val, np.inf)   # one ULP above the exact max
+    df = _summary([('METHANE', mean_ulp, val, val, val)])
+    res = _by_check(sc.check_summary_bounds(df, 'SiteSummary'))
+    assert res[('SiteSummary', 'mean_le_max')].count == 0
+    assert res[('SiteSummary', 'lowerCI_le_mean')].count == 0
+    assert res[('SiteSummary', 'mean_le_upperCI')].count == 0
+
+
+def test_summary_real_mean_over_max_still_flagged():
+    """A genuine mean>max (well beyond ULP) is still a violation."""
+    df = _summary([('METHANE', 10.1, 10.0, 3.0, 8.0)])
+    res = _by_check(sc.check_summary_bounds(df, 'SiteSummary'))
+    assert res[('SiteSummary', 'mean_le_max')].count == 1
+
+
 def test_summary_ci_disorder_is_warning_and_c2c1_excluded():
     df = _summary([
         ('METHANE', 5.0, 10.0, 6.0, 4.0),       # lowerCI>mean and mean>upperCI

--- a/test/test_summary_consistency.py
+++ b/test/test_summary_consistency.py
@@ -1,0 +1,228 @@
+"""
+Tests for SummaryConsistency.py — the directory-level Summary/ consistency checker.
+
+Each test builds minimal synthetic DataFrames for one check, asserts a clean
+fixture yields no violations, and an injected fault is flagged at the right
+severity. The cross-level rollup test mirrors the issue #77 triple-count; the
+PDF-vs-summary test confirms the #74 discrepancy is a warning, not a violation.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# SummaryConsistency lives in src/Testing/, which conftest does not add to the path.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'Testing'))
+
+import Units as u
+import SummaryConsistency as sc
+
+T_SECS = 365.0 * u.SECONDS_PER_DAY
+
+
+def _by_check(results):
+    return {(r.dataset, r.check): r for r in results}
+
+
+# ---------------------------------------------------------------------------
+# InstEmissions structural
+# ---------------------------------------------------------------------------
+
+def _inst(rows):
+    return pd.DataFrame(rows, columns=['timestamp_s', 'duration_s', 'emission_kgPerS', 'totalEmission_kg'])
+
+
+def test_instemissions_clean():
+    df = _inst([
+        (0.0, 3600.0, 0.001, 0.001 * 3600.0),
+        (1000.0, 5000.0, 0.002, 0.002 * 5000.0),
+    ])
+    res = _by_check(sc.check_instemissions(df, T_SECS))
+    assert all(r.ok for r in res.values()), res
+
+
+def test_instemissions_overrun_flagged():
+    start = T_SECS - 10 * u.SECONDS_PER_DAY
+    df = _inst([
+        (0.0, 3600.0, 0.001, 0.001 * 3600.0),                  # interior
+        (start, 110 * u.SECONDS_PER_DAY, 0.001,                 # overruns by 100 days
+         0.001 * 110 * u.SECONDS_PER_DAY),
+    ])
+    res = _by_check(sc.check_instemissions(df, T_SECS))
+    assert res[('InstEmissions', 'event_end_within_window')].count == 1
+    assert res[('InstEmissions', 'event_end_within_window')].severity == 'violation'
+
+
+def test_instemissions_negative_and_inconsistent_flagged():
+    df = _inst([
+        (-5.0, 3600.0, 0.001, 0.001 * 3600.0),       # negative timestamp (total consistent)
+        (0.0, -10.0, 0.001, 0.001 * -10.0),          # negative duration (total consistent)
+        (0.0, 3600.0, -0.001, -0.001 * 3600.0),      # negative emission (total consistent)
+        (0.0, 3600.0, 0.001, 999.0),                 # totalEmission inconsistent (isolated)
+    ])
+    res = _by_check(sc.check_instemissions(df, T_SECS))
+    assert res[('InstEmissions', 'timestamp_nonneg')].count == 1
+    assert res[('InstEmissions', 'duration_nonneg')].count == 1
+    assert res[('InstEmissions', 'emission_nonneg')].count == 1
+    assert res[('InstEmissions', 'totalEmission_consistent')].count == 1
+
+
+def test_instemissions_missing_duration_skips_window_check():
+    df = _inst([(0.0, 3600.0, 0.001, 0.001 * 3600.0)])
+    res = _by_check(sc.check_instemissions(df, None))
+    r = res[('InstEmissions', 'event_end_within_window')]
+    assert r.severity == 'warning' and r.count == 0 and 'skipped' in r.detail
+
+
+# ---------------------------------------------------------------------------
+# Summary bounds
+# ---------------------------------------------------------------------------
+
+def _summary(rows):
+    return pd.DataFrame(rows, columns=['species', 'mean', 'max', 'lowerCI', 'upperCI'])
+
+
+def test_summary_bounds_clean():
+    df = _summary([('METHANE', 5.0, 10.0, 3.0, 8.0)])
+    res = _by_check(sc.check_summary_bounds(df, 'SimSummary'))
+    assert all(r.ok for r in res.values())
+
+
+def test_summary_mean_gt_max_is_violation():
+    df = _summary([('METHANE', 12.0, 10.0, 3.0, 8.0)])
+    res = _by_check(sc.check_summary_bounds(df, 'SimSummary'))
+    assert res[('SimSummary', 'mean_le_max')].count == 1
+    assert res[('SimSummary', 'mean_le_max')].severity == 'violation'
+
+
+def test_summary_ci_disorder_is_warning_and_c2c1_excluded():
+    df = _summary([
+        ('METHANE', 5.0, 10.0, 6.0, 4.0),       # lowerCI>mean and mean>upperCI
+        ('C2/C1', 1.0, np.nan, np.nan, np.nan),  # excluded by design
+    ])
+    res = _by_check(sc.check_summary_bounds(df, 'SimSummary'))
+    assert res[('SimSummary', 'lowerCI_le_mean')].count == 1
+    assert res[('SimSummary', 'mean_le_upperCI')].count == 1
+    assert res[('SimSummary', 'lowerCI_le_mean')].severity == 'warning'
+    assert res[('SimSummary', 'mean_le_max')].count == 0  # C2/C1 NaN not counted
+
+
+# ---------------------------------------------------------------------------
+# PDF structural
+# ---------------------------------------------------------------------------
+
+def _pdf(rate, prob, cum, **idcols):
+    df = pd.DataFrame({'emissionRate_kgPerH': rate, 'probability': prob, 'cumulativeProbability': cum})
+    for k, v in idcols.items():
+        df[k] = v
+    return df
+
+
+def test_pdf_structural_clean():
+    df = _pdf([0.1, 0.2, 0.3], [0.2, 0.3, 0.5], [0.2, 0.5, 1.0], CICategory='siteTotals', site='S1')
+    res = _by_check(sc.check_pdf_structural(df, 'PDF'))
+    assert all(r.ok for r in res.values())
+
+
+def test_pdf_nonmonotone_cdf_flagged():
+    df = _pdf([0.1, 0.2, 0.3], [0.2, 0.3, 0.5], [0.2, 0.1, 1.0], CICategory='siteTotals', site='S1')
+    res = _by_check(sc.check_pdf_structural(df, 'PDF'))
+    assert res[('PDF', 'cdf_monotone')].count == 1
+
+
+def test_pdf_negative_probability_flagged():
+    df = _pdf([0.1, 0.2], [-0.1, 0.5], [0.0, 0.5], CICategory='siteTotals', site='S1')
+    res = _by_check(sc.check_pdf_structural(df, 'PDF'))
+    assert res[('PDF', 'probability_nonneg')].count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-level: SimSummary rollup (issue #77)
+# ---------------------------------------------------------------------------
+
+def _simrow(cic, mean, mec=None):
+    return {'species': 'METHANE', 'units': 'kg/year', 'includeFugitive': True,
+            'CICategory': cic, 'mean': mean, 'modelEmissionCategory': mec}
+
+
+def _simsummary(sim_total=100.0, level_total=100.0):
+    """simulation == sim_total; every other level (and COMBINED) sums to level_total.
+    Balanced when the two are equal; #77 is sim_total = 3 * level_total."""
+    return pd.DataFrame([
+        _simrow('simulation', sim_total),
+        _simrow('modelReadableName', 0.6 * level_total), _simrow('modelReadableName', 0.4 * level_total),
+        _simrow('METype', 0.7 * level_total), _simrow('METype', 0.3 * level_total),
+        _simrow('unitID', 0.55 * level_total), _simrow('unitID', 0.45 * level_total),
+        _simrow('modelEmissionCategory', level_total, mec='COMBINED'),
+        _simrow('modelEmissionCategory', 0.6 * level_total, mec='VENTED'),
+        _simrow('modelEmissionCategory', 0.4 * level_total, mec='FUGITIVE'),
+    ])
+
+
+def test_simsummary_rollup_balanced():
+    res = _by_check(sc.check_simsummary_rollup(_simsummary()))
+    assert all(r.ok for r in res.values()), res
+
+
+def test_simsummary_rollup_triple_count_flagged():
+    """Mirror issue #77: simulation is 3x the (correct) level totals."""
+    df = _simsummary(sim_total=300.0, level_total=100.0)
+    res = _by_check(sc.check_simsummary_rollup(df))
+    assert res[('SimSummary', 'simulation_eq_modelReadableName')].count == 1
+    assert res[('SimSummary', 'simulation_eq_METype')].count == 1
+    assert res[('SimSummary', 'simulation_eq_unitID')].count == 1
+    assert res[('SimSummary', 'simulation_eq_modelEmissionCategory')].count == 1
+    assert all(r.severity == 'violation' for r in res.values())
+
+
+# ---------------------------------------------------------------------------
+# Cross-level: PDF vs summary mean (issue #74) — warning, not violation
+# ---------------------------------------------------------------------------
+
+def _pdf_sitetotals(mean_kgh, site='S1'):
+    # single delta at rate=mean_kgh with probability 1 → PDF mean == mean_kgh
+    return _pdf([mean_kgh], [1.0], [1.0], CICategory='siteTotals', site=site,
+                species='METHANE', includeFugitive=True)
+
+
+def _sitesummary_combined(mean_kgyr, site='S1'):
+    return pd.DataFrame([{
+        'site': site, 'species': 'METHANE', 'includeFugitive': True,
+        'CICategory': 'modelEmissionCategory', 'modelEmissionCategory': 'COMBINED',
+        'units': 'kg/year', 'mean': mean_kgyr,
+    }])
+
+
+def test_pdf_vs_summary_match():
+    mean_kgh = 0.5
+    pdf = _pdf_sitetotals(mean_kgh)
+    site = _sitesummary_combined(mean_kgh * u.HOURS_PER_YEAR)
+    res = _by_check(sc.check_pdf_vs_summary_mean(pdf, site))
+    r = res[('PDF', 'pdf_mean_eq_summary_mean')]
+    assert r.count == 0 and r.severity == 'warning'
+
+
+def test_pdf_vs_summary_mismatch_is_warning_not_violation():
+    pdf = _pdf_sitetotals(0.45)                                   # 10% below
+    site = _sitesummary_combined(0.5 * u.HOURS_PER_YEAR)
+    res = _by_check(sc.check_pdf_vs_summary_mean(pdf, site))
+    r = res[('PDF', 'pdf_mean_eq_summary_mean')]
+    assert r.count == 1
+    assert r.severity == 'warning'   # #74 is open/unresolved → never a hard violation
+
+
+# ---------------------------------------------------------------------------
+# Orchestration switches
+# ---------------------------------------------------------------------------
+
+def test_switches_select_tiers():
+    dfs = {'SimSummary': _simsummary(sim_total=300.0, level_total=100.0)}  # has a cross-level fault
+    # structural only → rollup fault not examined
+    sres = sc.run_checks(dfs, structural=True, cross_level=False)
+    assert all(r.severity != 'violation' or r.ok for r in sres)
+    # cross-level on → fault surfaces
+    xres = sc.run_checks(dfs, structural=False, cross_level=True)
+    assert any((not r.ok) and r.severity == 'violation' for r in xres)


### PR DESCRIPTION
## Summary

New `src/Testing/SummaryConsistency.py` — runs invariant checks over a MAES `Summary/` parquet directory. Unlike `SummaryTest.py` (new-vs-legacy comparison driven by a scenario config), it operates on a **directory alone** and is unit-testable on synthetic DataFrames.

Two independently switchable tiers:

**structural**
- `InstEmissions`: non-negative timestamps/durations/emissions; events do not overrun the simulation window (**#87**); `totalEmission_kg` consistent with rate × duration.
- `SiteSummary`/`SimSummary`: `mean ≤ max` (violation); CI-bound ordering (warning). Comparisons use a small relative tolerance so a constant-rate emitter — whose `mean = sum/N` can land ~1 ULP above the exact `max` from float64 rounding — is not flagged spuriously.
- `PDF`/`SimPDF`: probability ≥ 0, CDF monotone and bounded by 1.

**cross-level**
- `SimSummary` rollup: `simulation` total equals the sum over modelReadableName / METype / unitID and the modelEmissionCategory COMBINED row (**#77**, violation).
- per-site `siteTotals` PDF mean vs `SiteSummary` site-total mean (**#74**, **warning** — #74 is an open, unresolved discrepancy, so this identity is not yet a guaranteed invariant).

## CLI

```
python src/Testing/SummaryConsistency.py <Summary dir> \
  [--structural/--no-structural] [--cross-level/--no-cross-level] [--rtol 1e-6] [--warn-rtol 0.05]
```
`simDurationSecs` is read from the `simDurationDays` column; absent datasets are skipped; non-zero exit only on violations.

## Validated on real output (`JennaBug2`)

- 12,958 window overruns (#87), all rollup combos (#77), #74 mismatch as a warning, exit 1.
- `SiteSummary`/`SimSummary` bounds clean. (An initial run showed 388 `mean > max` rows; on inspection all were `min==max` constant-rate emitters with a ~1e-16 relative gap — float64 ULP noise, **not** a bug — which is why the bounds checks now apply a relative tolerance.)

## Tests

`test/test_summary_consistency.py` — 17 tests; clean fixture + injected fault per check (incl. an #77 triple-count mirror, a 1-ULP `mean>max` that must NOT flag vs a genuine one that must, and confirmation #74 is a warning, never a violation). Full maintained suite green.

> Note: the #77 and #87 cross-level/structural checks will report violations against current `Summary_Rewrite` output until PRs #98 (#77) and #99 (#87) merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
