### PR TITLE
Aggregate SimSummary across all sites + job-level output (issue #101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 
 ## v0.4.0 (unreleased)
 
+### Bug Fixes (2026-06-01)
+
+- **SiteMain2.py** / **Summaries2.py** — the simulation-level summary now aggregates **all**
+  sites (issue #101). The single `simSummary` workitem is generated once after the study
+  loop, so it inherited whichever site's config the config manager was left on (the last
+  study). As a result `summarizeSimulation` / `createSimPDF` read only that one site's
+  `SiteSummary` / `PDF` (`SimPDF mixture: 1 sites`) and the `simulation`-level total
+  reflected a single site rather than the whole simulation. `generateWorkitems` now
+  accumulates every site's `SiteSummary` and `PDF` output directory and threads them onto
+  the workitem (`allSiteSummaryDirs` / `allSitePDFDirs`); a new `_readSummaryAcrossSites`
+  helper reads and concatenates across them (each per-site dataset is hive-partitioned by
+  `site`, so the column is reconstructed and preserved). Falls back to the single
+  configured path for single-study runs.
+
+### Schema Changes (2026-06-01)
+
+- **defaultConfig.json**: `SimSummary` and `SimPDF` are now written to a deterministic,
+  job-level location (issue #101). Added `simulationParquetDir` =
+  `{outputRoot}/MC_{scenarioTimestamp}/parquet`; `parquetNewSimSummary` and
+  `parquetNewSimPDF` resolve under it (`{simulationParquetDir}/Summary/SimSummary` and
+  `.../SimPDF`) instead of the per-study `{parquetDir}/Summary/...`. Previously these
+  simulation-wide datasets landed under whichever site was processed last; they now live
+  at the job root, independent of study order. Per-site datasets (`SiteSummary`, `PDF`,
+  `InstEmissions`, `EventSummary`, `PDFCache`) are unchanged.
+
+### Tests (2026-06-01)
+
+- **test/test_issue101_simsummary_aggregation.py**: new test file (issue #101). Covers the
+  `_readSummaryAcrossSites` helper aggregating across sites and its single-path fallback;
+  `summarizeSimulation` producing a `simulation` total that sums all sites (not just the
+  last); `createSimPDF` mixing every site's PDF (vs. the old single-site mixture); and the
+  job-level, site-independent `SimSummary` / `SimPDF` write paths.
+
 ### Schema Changes (2026-03-31)
 
 - **defaultConfig.json** / **ParquetLib.py**: renamed the new Parquet summary directory

--- a/config/defaultConfig.json
+++ b/config/defaultConfig.json
@@ -63,6 +63,7 @@
       "equipmentFile": "{templateDir}/equipment.json",
       "mdIndexFile": "{templateDir}/mdIndex.csv",
       "parquetDir": "{simulationRoot}/parquet",
+      "simulationParquetDir": "{outputRoot}/MC_{scenarioTimestamp}/parquet",
 
       "parquetEventDS":          "{parquetDir}/events",
       "parquetTimeseriesDS":     "{parquetDir}/timeseries",
@@ -72,11 +73,11 @@
       "parquetEventListDS":      "{parquetDir}/eventList",
       "parquetNewSummary":       "{parquetDir}/Summary/SiteSummary",
       "parquetNewInstEmissions": "{parquetDir}/Summary/InstEmissions",
-      "parquetNewSimSummary":    "{parquetDir}/Summary/SimSummary",
+      "parquetNewSimSummary":    "{simulationParquetDir}/Summary/SimSummary",
       "parquetNewEventSummary":  "{parquetDir}/Summary/EventSummary",
       "parquetNewPDF":      "{parquetDir}/Summary/PDF",
       "parquetNewPDFCache": "{parquetDir}/Summary/PDFCache",
-      "parquetNewSimPDF":   "{parquetDir}/Summary/SimPDF"
+      "parquetNewSimPDF":   "{simulationParquetDir}/Summary/SimPDF"
     },
 
     "MCIteration": {

--- a/src/SiteMain2.py
+++ b/src/SiteMain2.py
@@ -176,6 +176,12 @@ def generateWorkitems(cm, phasesToInclude=ALL_PHASES):
     createPDFCacheWorkitems = []
     simSummaryWorkitems = []
 
+    # The per-site SiteSummary/PDF output dirs, accumulated as each site's config
+    # is expanded. The single simSummary workitem aggregates across all of these,
+    # rather than seeing only the last site left in the config manager.
+    allSiteSummaryDirs = []
+    allSitePDFDirs = []
+
     fileList = getFileList(cm)
     for (fullFilename, studyFilename, studyName) in fileList:
         cm.expandPhase("arguments", studyDefinitionFile=studyFilename)
@@ -194,8 +200,12 @@ def generateWorkitems(cm, phasesToInclude=ALL_PHASES):
         summaryWI = generateSingleWorkitem(cm, 'summarize')
         summaryWorkitems.append(summaryWI)
         createPDFCacheWorkitems.append(generateSingleWorkitem(cm, 'createPDFCache'))
-    # simSummary happens once per simulation
+        allSiteSummaryDirs.append(cm.getConfigVar('parquetNewSummary'))
+        allSitePDFDirs.append(cm.getConfigVar('parquetNewPDF'))
+    # simSummary happens once per simulation, aggregating every site's summaries
     simSummaryWI = generateSingleWorkitem(cm, 'simSummary')
+    simSummaryWI['allSiteSummaryDirs'] = allSiteSummaryDirs
+    simSummaryWI['allSitePDFDirs'] = allSitePDFDirs
     simSummaryWorkitems.append(simSummaryWI)
 
     retWorkitems = []

--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -916,10 +916,25 @@ def _computeSimC2C1(inDF, CICategory, mcIterations, pivotField=None):
     return retDF
 
 
+def _readSummaryAcrossSites(config, dirsKey, fallbackKey, **readKwargs):
+    """Read and concatenate a per-site Summary dataset (e.g. SiteSummary, PDF)
+    across every site in the simulation.
+
+    ``dirsKey`` holds the list of per-site dataset directories threaded onto the
+    simSummary workitem by ``generateWorkitems``. When absent (single-study runs,
+    or direct callers that did not populate it) this falls back to the single
+    configured ``fallbackKey`` path. Each per-site directory is hive-partitioned
+    by ``site``, so the column is reconstructed on read and preserved by concat.
+    """
+    dirs = config.get(dirsKey) or [config[fallbackKey]]
+    frames = [pd.read_parquet(d, **readKwargs) for d in dirs]
+    return pd.concat(frames, ignore_index=True)
+
 def createSimPDF(config):
     logger.info("Creating simulation-level PDF (mixture approach)")
 
-    siteList = pd.read_parquet(config['parquetNewPDF'], columns=['site'])['site'].unique().tolist()
+    siteList = _readSummaryAcrossSites(config, 'allSitePDFDirs', 'parquetNewPDF',
+                                       columns=['site'])['site'].unique().tolist()
     if not siteList:
         logger.info("No PDF data, skipping SimPDF")
         return
@@ -928,8 +943,8 @@ def createSimPDF(config):
     allPDFRowsList = []
     for siteCacheLevel, simCacheLevel, simGroupCols in SIM_PDF_LEVEL_MAP:
         logger.info(f"SimPDF mixture: {siteCacheLevel} -> {simCacheLevel}")
-        sitePDFDF = pd.read_parquet(config['parquetNewPDF'],
-                                    filters=[('CICategory', '=', siteCacheLevel)])
+        sitePDFDF = _readSummaryAcrossSites(config, 'allSitePDFDirs', 'parquetNewPDF',
+                                            filters=[('CICategory', '=', siteCacheLevel)])
         if sitePDFDF.empty:
             continue
 
@@ -962,10 +977,11 @@ def createSimPDF(config):
 
 def summarizeSimulation(config):
     # this method depends on site-level simulations (aka 'summarize' function) being performed prior to this call.
-    logger.info(f"{config['parquetNewSummary']=}")
+    summaryDirs = config.get('allSiteSummaryDirs') or [config['parquetNewSummary']]
+    logger.info(f"summarizeSimulation: aggregating {len(summaryDirs)} site summary dir(s)")
     with Timer("Read summaries") as t0:
         logging.info("Read summary parquet files")
-        fullSummaryDF = pd.read_parquet(config['parquetNewSummary'])
+        fullSummaryDF = _readSummaryAcrossSites(config, 'allSiteSummaryDirs', 'parquetNewSummary')
         t0.setCount(len(fullSummaryDF))
 
     mcIterations = config['monteCarloIterations']

--- a/test/test_issue101_simsummary_aggregation.py
+++ b/test/test_issue101_simsummary_aggregation.py
@@ -1,0 +1,188 @@
+"""
+Tests for GitHub issue #101 — simulation-level summary must aggregate ALL sites
+and be written to a deterministic, site-independent job-level location.
+
+The bug: the single ``simSummary`` workitem inherited whatever site's config the
+config manager was left on after the file loop (the last study). As a result
+``summarizeSimulation`` / ``createSimPDF`` read only that one site's
+``SiteSummary`` / ``PDF`` (``SimPDF mixture: 1 sites``) and wrote the sim-level
+datasets under that arbitrary site's directory.
+
+The fix threads every site's per-site dataset directory onto the workitem
+(``allSiteSummaryDirs`` / ``allSitePDFDirs``) and points the SimSummary/SimPDF
+write paths at a job-level ``simulationParquetDir``.
+"""
+
+import json
+import os
+
+import numpy as np
+import pandas as pd
+
+from Summaries2 import (
+    _readSummaryAcrossSites,
+    summarizeSimulation,
+    createSimPDF,
+)
+
+MC_ITERATIONS = 2
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'defaultConfig.json')
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — write per-site, hive-partitioned (by site) parquet dirs.
+# ---------------------------------------------------------------------------
+
+def _write_site_summary(base_dir, site, reading):
+    """One SiteSummary 'COMBINED' modelEmissionCategory row for a site, with a
+    constant per-MC-run ``reading``. Returns the directory written."""
+    df = pd.DataFrame([{
+        'species': 'METHANE',
+        'units': 'kg/year',
+        'includeFugitive': False,
+        'CICategory': 'modelEmissionCategory',
+        'modelEmissionCategory': 'COMBINED',
+        'modelReadableName': 'src',
+        'unitID': 'u1',
+        'METype': 'mt1',
+        'pneumatic': 'none',
+        'readings': [float(reading)] * MC_ITERATIONS,
+        'mean': float(reading),
+        'site': site,
+    }])
+    out = os.path.join(base_dir, site, 'SiteSummary')
+    df.to_parquet(out, partition_cols=['site'], index=False)
+    return out
+
+
+def _write_site_pdf(base_dir, site, rate):
+    """One siteTotals PDF row (one component) for a site at emission ``rate``."""
+    df = pd.DataFrame([{
+        'species': 'METHANE',
+        'includeFugitive': False,
+        'CICategory': 'siteTotals',
+        'site': site,
+        'operator': 'op',
+        'psno': 'ps',
+        'emissionRate_kgPerH': float(rate),
+        'probability': 1.0,
+    }])
+    out = os.path.join(base_dir, site, 'PDF')
+    df.to_parquet(out, partition_cols=['site'], index=False)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. The read helper aggregates across every site and preserves `site`.
+# ---------------------------------------------------------------------------
+
+def test_read_summary_across_sites_aggregates_all_sites(tmp_path):
+    base = str(tmp_path / 'out')
+    dir_a = _write_site_summary(base, 'siteA', 2.0)
+    dir_b = _write_site_summary(base, 'siteB', 3.0)
+
+    config = {'allSiteSummaryDirs': [dir_a, dir_b]}
+    result = _readSummaryAcrossSites(config, 'allSiteSummaryDirs', 'parquetNewSummary')
+
+    assert set(result['site']) == {'siteA', 'siteB'}, "both sites must be read"
+    assert len(result) == 2
+
+
+def test_read_summary_across_sites_falls_back_to_single_path(tmp_path):
+    """With no threaded list, the helper reads the single configured path
+    (single-study runs / direct callers)."""
+    base = str(tmp_path / 'out')
+    dir_b = _write_site_summary(base, 'siteB', 3.0)
+
+    config = {'parquetNewSummary': dir_b}  # no allSiteSummaryDirs
+    result = _readSummaryAcrossSites(config, 'allSiteSummaryDirs', 'parquetNewSummary')
+
+    assert set(result['site']) == {'siteB'}
+
+
+# ---------------------------------------------------------------------------
+# 2. summarizeSimulation: the 'simulation' total sums across ALL sites.
+# ---------------------------------------------------------------------------
+
+def test_summarize_simulation_totals_span_all_sites(tmp_path):
+    base = str(tmp_path / 'out')
+    summary_a = _write_site_summary(base, 'siteA', 2.0)
+    summary_b = _write_site_summary(base, 'siteB', 3.0)
+    pdf_a = _write_site_pdf(base, 'siteA', 10.0)
+    pdf_b = _write_site_pdf(base, 'siteB', 20.0)
+
+    sim_dir = str(tmp_path / 'job' / 'SimSummary')
+    config = {
+        'allSiteSummaryDirs': [summary_a, summary_b],
+        'allSitePDFDirs': [pdf_a, pdf_b],
+        # fallback single paths point at the LAST site, mirroring the old bug:
+        'parquetNewSummary': summary_b,
+        'parquetNewPDF': pdf_b,
+        'parquetNewSimSummary': sim_dir,
+        'parquetNewSimPDF': str(tmp_path / 'job' / 'SimPDF'),
+        'monteCarloIterations': MC_ITERATIONS,
+        'simDurationDays': 365,
+    }
+
+    summarizeSimulation(config)
+
+    sim = pd.read_parquet(sim_dir)
+    simRows = sim[sim['CICategory'] == 'simulation']
+    assert not simRows.empty, "simulation rollup rows must be written"
+
+    # siteA=2 + siteB=3 per run → cross-site run total 5; mean = 5 (sum/N).
+    # The pre-fix single-(last-)site value would have been 3.
+    total = simRows['total'].sum()
+    mean = simRows['mean'].sum()
+    assert abs(mean - 5.0) < 1e-9, f"simulation mean must span both sites (got {mean}, last-site-only would be 3.0)"
+    assert abs(total - 10.0) < 1e-9, f"simulation total must span both sites (got {total})"
+
+
+# ---------------------------------------------------------------------------
+# 3. createSimPDF mixes every site (was 'SimPDF mixture: 1 sites').
+# ---------------------------------------------------------------------------
+
+def test_create_simpdf_mixes_all_sites(tmp_path):
+    base = str(tmp_path / 'out')
+    pdf_a = _write_site_pdf(base, 'siteA', 10.0)
+    pdf_b = _write_site_pdf(base, 'siteB', 20.0)
+
+    sim_pdf_dir = str(tmp_path / 'job' / 'SimPDF')
+    config = {
+        'allSitePDFDirs': [pdf_a, pdf_b],
+        'parquetNewPDF': pdf_b,           # last-site fallback (old bug source)
+        'parquetNewSimPDF': sim_pdf_dir,
+    }
+
+    createSimPDF(config)
+
+    simpdf = pd.read_parquet(sim_pdf_dir)
+    rates = set(simpdf['emissionRate_kgPerH'].tolist())
+    assert rates == {10.0, 20.0}, f"SimPDF must mix both sites' rates, got {rates}"
+    # Two equal components → each scaled to 0.5; CDF reaches 1.0.
+    assert abs(simpdf['probability'].sum() - 1.0) < 1e-9
+    assert abs(simpdf['cumulativeProbability'].max() - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# 4. Write location is deterministic & job-level (no per-site component).
+# ---------------------------------------------------------------------------
+
+def test_simsummary_write_path_is_job_level():
+    with open(CONFIG_PATH) as f:
+        cfg = json.load(f)
+    sim_phase = cfg['phaseValues']['simulation']
+
+    assert sim_phase['parquetNewSimSummary'] == '{simulationParquetDir}/Summary/SimSummary'
+    assert sim_phase['parquetNewSimPDF'] == '{simulationParquetDir}/Summary/SimPDF'
+
+    # The job-level dir resolves from job-wide vars ONLY — referencing the
+    # per-site {parquetDir}/{studyName}/{site} would make format_map raise here.
+    resolved = sim_phase['simulationParquetDir'].format_map({
+        'outputRoot': '/out',
+        'scenarioTimestamp': 'TS',
+    })
+    assert resolved == '/out/MC_TS/parquet'
+
+    # Per-site SiteSummary stays per-site (unchanged).
+    assert sim_phase['parquetNewSummary'] == '{parquetDir}/Summary/SiteSummary'


### PR DESCRIPTION
## Issue #101 — simulation summary aggregated only the last site, stored under an arbitrary site

The single `simSummary` workitem is generated once **after** the study loop in `generateWorkitems`, so it inherited whichever site's config the config manager was left on — the last study. As a result:

- `summarizeSimulation` read only that one site's `SiteSummary` (`config['parquetNewSummary']` resolved to the last study's per-site dir), so the `simulation`-level total reflected a **single site**, not the whole simulation.
- `createSimPDF` read only that site's `PDF` — hence the telltale `SimPDF mixture: 1 sites` in the logs.
- `SimSummary` / `SimPDF` were written under that arbitrary site's directory, so their location depended on study order.

This only affects the non-bundle (per-study directory) output path. In bundle mode (`BundleRunner`, not on this branch) all sites share one job-level `parquetDir`, so the same reads already see every site.

## Fix

**Aggregate across all sites — from the config, not the filesystem.**
`generateWorkitems` already enumerates every site (`getFileList` over the input study directory) and eagerly expands each site's output paths. It now accumulates each site's `SiteSummary` and `PDF` directory and threads them onto the workitem (`allSiteSummaryDirs` / `allSitePDFDirs`). A new `_readSummaryAcrossSites` helper reads and concatenates across them; each per-site dataset is hive-partitioned by `site`, so the column is reconstructed and preserved (which `createSimPDF`'s mixture normalization needs). Falls back to the single configured path for single-study runs.

**Deterministic, job-level write location.**
Added `simulationParquetDir = {outputRoot}/MC_{scenarioTimestamp}/parquet`; `parquetNewSimSummary` / `parquetNewSimPDF` now resolve under it (`{simulationParquetDir}/Summary/SimSummary` / `.../SimPDF`) instead of the per-study `{parquetDir}/Summary/...`. This matches the `Summary/SimSummary` suffix bundle mode already uses, so the sim-level layout converges toward the bundle layout. Per-site datasets (`SiteSummary`, `PDF`, `InstEmissions`, `EventSummary`, `PDFCache`) are unchanged.

## Output-layout change (reviewers note)

`SimSummary` / `SimPDF` move from `<job>/<lastSite>/MC_<ts>/parquet/Summary/` to `<job>/MC_<ts>/parquet/Summary/`. Any tooling on `Summary_Rewrite` that located `SimSummary` under a site directory will need the new job-level path. `SummaryTest` and other engine-internal readers resolve via the same config keys, so they follow automatically.

## Verification

- New `test/test_issue101_simsummary_aggregation.py` (5 tests): `_readSummaryAcrossSites` aggregates across sites and falls back to a single path; `summarizeSimulation` produces a `simulation` total that sums all sites (not just the last); `createSimPDF` mixes every site's PDF; the `SimSummary` / `SimPDF` write paths are job-level and site-independent.
- Full maintained suite green in the MAES env — **45 passed** — including the end-to-end engine runs (`test_smoke::test_minimal_run`, `test_rng_consolidation::test_seeded_sim_run_reproducible`) that execute `SiteMain2.py` and exercise the changed `generateWorkitems` + config.

## Scope

- Independent of the other in-flight `Summary_Rewrite` PRs (#98 / #99 / #100).
- Consolidating the **per-site** datasets into a job-level tree is the bundle split's job (`BundleRunner`, already on `main`), not this fix's — #101 only relocates the two simulation-wide datasets, which is where the bug was.
- Interacts with #94 (SimPDF mixture normalization now spans all sites' components rather than one site's) but does not attempt to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
