### PR TITLE
Consolidate -dr Summary output to a job-level location (match bundle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 
 ## v0.4.0 (unreleased)
 
+### Schema Changes (2026-06-02)
+
+- **defaultConfig.json**: `-dr` (directory) runs now consolidate their `Summary/` parquet
+  tree into a single **job-level** location, matching bundle output. `summaryParquetDir`'s
+  default changed from the per-study `{parquetDir}` to `{outputRoot}/MC_{scenarioTimestamp}/parquet`.
+  Because every `parquetNew*` summary key already resolves through `summaryParquetDir`, this
+  moves **both** the site-level datasets (`SiteSummary`, `InstEmissions`, `EventSummary`,
+  `PDF`, `PDFCache`, hive-partitioned by `site`) and the sim-level datasets (`SimSummary`,
+  `SimPDF`) — plus `SummaryLegacy` — from `<outputRoot>/<site>/MC_<ts>/parquet/Summary/` to
+  the consolidated `<outputRoot>/MC_<ts>/parquet/Summary/`. Bundle mode is unaffected: it
+  sets `summaryParquetDir` explicitly via `bundleSummaryParquetDir` and overrides the default.
+  Non-summary parquet (`events`, `timeseries`, `gascomposition`, `metadata`, `eventList`)
+  stays per-study under `{parquetDir}`. Consumers that located `-dr` Summary output under a
+  per-site directory must read the job-level path instead.
+
+### Tests (2026-06-02)
+
+- **test/test_dr_consolidated_summary_layout.py**: asserts that a `-dr` run resolves every
+  Summary dataset to a study-independent (job-level) path while per-site raw parquet stays
+  study-specific, and that `summaryParquetDir` resolves to `{outputRoot}/MC_{scenarioTimestamp}/parquet`.
+
 ### Schema Changes (2026-03-31)
 
 - **defaultConfig.json** / **ParquetLib.py**: renamed the new Parquet summary directory

--- a/config/defaultConfig.json
+++ b/config/defaultConfig.json
@@ -64,7 +64,7 @@
       "equipmentFile": "{templateDir}/equipment.json",
       "mdIndexFile": "{templateDir}/mdIndex.csv",
       "parquetDir": "{simulationRoot}/parquet",
-      "summaryParquetDir": "{parquetDir}",
+      "summaryParquetDir": "{outputRoot}/MC_{scenarioTimestamp}/parquet",
 
       "parquetEventDS":          "{parquetDir}/events",
       "parquetTimeseriesDS":     "{parquetDir}/timeseries",

--- a/test/test_dr_consolidated_summary_layout.py
+++ b/test/test_dr_consolidated_summary_layout.py
@@ -1,0 +1,67 @@
+"""
+Tests that a directory (`-dr`) run consolidates its Summary parquet datasets into a
+single job-level location, matching the bundle layout.
+
+The engine routes every `parquetNew*` summary key (site-level *and* sim-level) through
+`summaryParquetDir`. Bundle mode overrides that to a job-level dir; the non-bundle path
+uses the config default. This change flips that default from the per-study `{parquetDir}`
+to a job-level `{outputRoot}/MC_{scenarioTimestamp}/parquet`, so `-dr` consolidates too.
+
+Invariant under test: the Summary datasets resolve to a path that is **independent of
+the study/site**, while the per-site raw (non-summary) parquet stays study-specific.
+"""
+
+import json
+import os
+
+from ConfigManager import ConfigManager
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'defaultConfig.json')
+
+SUMMARY_KEYS = ['summaryParquetDir', 'parquetNewSummary', 'parquetNewInstEmissions',
+                'parquetNewEventSummary', 'parquetNewPDF', 'parquetNewPDFCache',
+                'parquetNewSimSummary', 'parquetNewSimPDF', 'parquetSummaryDS']
+PER_SITE_KEYS = ['parquetDir', 'parquetEventDS', 'parquetTimeseriesDS']
+
+
+def _resolve_for_study(study_name, output_root='/out', ts='TS'):
+    """Drive ConfigManager through the phases a `-dr` run uses for one study and
+    return the resolved path config vars."""
+    with open(CONFIG_PATH) as f:
+        config = json.load(f)
+    ConfigManager._initializeSingleton(config)
+    cm = ConfigManager
+    cm.expandPhase('defaultValues', outputRoot=output_root)
+    cm.expandPhase('arguments', studyDefinitionFile=f'{study_name}.xlsx', studyName=study_name)
+    cm.expandPhase('start', site=study_name, scenarioTimestamp=ts)
+    cm.expandPhase('simulation')
+    return {k: cm.getConfigVar(k) for k in SUMMARY_KEYS + PER_SITE_KEYS}
+
+
+def test_summary_paths_are_study_independent():
+    """Two different studies in the same job resolve every Summary dataset to the
+    SAME (job-level) location — that is what makes the layout consolidated."""
+    a = _resolve_for_study('siteA')
+    b = _resolve_for_study('siteB')
+    for k in SUMMARY_KEYS:
+        assert a[k] == b[k], f"{k} must be study-independent, got {a[k]!r} vs {b[k]!r}"
+        assert 'siteA' not in a[k] and 'siteB' not in b[k], f"{k} still embeds the study name: {a[k]!r}"
+
+
+def test_per_site_raw_paths_stay_study_specific():
+    """Non-summary (raw) parquet remains per-study — only the Summary tree consolidates."""
+    a = _resolve_for_study('siteA')
+    b = _resolve_for_study('siteB')
+    for k in PER_SITE_KEYS:
+        assert a[k] != b[k], f"{k} should stay per-study, but both resolved to {a[k]!r}"
+        assert 'siteA' in a[k] and 'siteB' in b[k]
+
+
+def test_summary_dir_is_job_level():
+    """summaryParquetDir resolves from job-wide vars only (outputRoot + scenarioTimestamp)."""
+    a = _resolve_for_study('siteA', output_root='/out', ts='TS')
+    assert a['summaryParquetDir'] == '/out/MC_TS/parquet'
+    assert a['parquetNewSummary'] == '/out/MC_TS/parquet/Summary/SiteSummary'
+    assert a['parquetNewSimSummary'] == '/out/MC_TS/parquet/Summary/SimSummary'
+    # per-site parquet is the per-study sibling, NOT the job-level dir
+    assert a['parquetDir'] == '/out/siteA/MC_TS/parquet'

--- a/test/test_rng_consolidation.py
+++ b/test/test_rng_consolidation.py
@@ -23,6 +23,7 @@ import subprocess
 import tempfile
 
 import numpy as np
+import pandas as pd
 import pytest
 import scipy.stats
 
@@ -120,13 +121,13 @@ def test_seeded_sim_run_reproducible(tmp_path: pathlib.Path) -> None:
     run_sim(dir_a)
     run_sim(dir_b)
 
-    import pyarrow.dataset as ds
-
     def load_totals(out_dir: pathlib.Path) -> np.ndarray:
         pq_dirs = list(out_dir.rglob("InstEmissions"))
         assert pq_dirs, f"No InstEmissions parquet found under {out_dir}"
-        dataset = ds.dataset(str(pq_dirs[0]), format="parquet")
-        df = dataset.to_table().to_pandas()
+        # Read like the rest of the engine (summarizeSimulation/createSimPDF): pd.read_parquet
+        # reconstructs hive partition columns (site, mcRun) automatically. InstEmissions is
+        # partitioned by ['site', 'mcRun'], so mcRun is path-encoded, not a file column.
+        df = pd.read_parquet(str(pq_dirs[0]))
         return df.groupby("mcRun")["totalEmission_kg"].sum().sort_index().values
 
     totals_a = load_totals(dir_a)


### PR DESCRIPTION
## Summary

Make a directory (`-dr`) run consolidate its `Summary/` parquet tree into a single **job-level** location, matching bundle output. This converges the two output formats so consumers read the same layout regardless of how the engine was launched.

## Change

One default flip in `config/defaultConfig.json`:

```
summaryParquetDir: "{parquetDir}"  →  "{outputRoot}/MC_{scenarioTimestamp}/parquet"
```

Every `parquetNew*` summary key already resolves through `summaryParquetDir`, so this moves the **whole** `Summary/` tree at once:

- **site-level** datasets — `SiteSummary`, `InstEmissions`, `EventSummary`, `PDF`, `PDFCache` (hive-partitioned by `site`)
- **sim-level** datasets — `SimSummary`, `SimPDF`
- plus `SummaryLegacy`

from the per-study `<outputRoot>/<study>/MC_<ts>/parquet/Summary/` to the consolidated `<outputRoot>/MC_<ts>/parquet/Summary/`.

Non-summary parquet (`events`, `timeseries`, `gascomposition`, `metadata`, `eventList`) stays per-study under `{parquetDir}` — unchanged.

**Bundle mode is unaffected.** It sets `summaryParquetDir` explicitly via `bundleSummaryParquetDir` (the `generateWorkitems` override), so it overrides this default and behaves exactly as before. The concurrent-write prerequisite (`overwrite_or_ignore`, `84b987f`) is already on this branch, so the consolidated shared-dataset writes are safe.

## Breaking change for consumers

`-dr` Summary output now lives at the job level. Anything that located it under a per-site directory (e.g. by globbing `*/MC_*/parquet` and looking for `Summary/` there) must read `<outputRoot>/MC_<ts>/parquet/Summary/` instead. The MAESPlatform connector `getResultsDir` is the known consumer that needs a corresponding update (tracked separately).

## Tests

- **`test/test_dr_consolidated_summary_layout.py`** (new): asserts that a `-dr` run resolves every Summary dataset to a **study-independent** (job-level) path while per-site raw parquet stays study-specific, and that `summaryParquetDir` resolves to `{outputRoot}/MC_{scenarioTimestamp}/parquet`.
- **`test/test_rng_consolidation.py`** (fix): `load_totals` now reads `InstEmissions` with `pd.read_parquet` — the same way `summarizeSimulation` / `createSimPDF` read partitioned datasets — instead of a bespoke `pyarrow.dataset` call that did not reconstruct hive partition columns.

  This was a **pre-existing** failure on `Bundle_Memory`, unrelated to this change: commit `97814ce` moved `mcRun` into the `InstEmissions` partition path, so the partition-unaware read raised `KeyError: 'mcRun'`. The engine output was verified bit-for-bit reproducible (`run_a == run_b`); only the test's read was wrong.

Full maintained suite green in the MAES env (the previously-failing reproducibility test now passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
