### PR TITLE
README: remove stale committed merge-conflict markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@
   Summary dataset to a study-independent (job-level) path while per-site raw parquet stays
   study-specific, and that `summaryParquetDir` resolves to `{outputRoot}/MC_{scenarioTimestamp}/parquet`.
 
+### Documentation (2026-06-02)
+
+- **README.md**: removed stale, accidentally-committed merge-conflict markers (`<<<<<<<` /
+  `=======` / `>>>>>>>`) around the `### Usage` section, present since the `eb2631f2` main
+  merge (2025-01-24). Kept the Usage section.
+
 ### Schema Changes (2026-03-31)
 
 - **defaultConfig.json** / **ParquetLib.py**: renamed the new Parquet summary directory

--- a/README.md
+++ b/README.md
@@ -36,12 +36,8 @@ assume it is c:\MAES-Project.
 1. This should produce a MAES run in the pycharm output window.  
 If it does so, you have successfully installed & configured MAES.
 
-<<<<<<< HEAD
 ### Usage
 To run MAES, run the following command:
 ```bash
 python src/SiteMain2.py -mc 2 -s C3/C3_Prototypical_Sites/P3_2stages_VRU.xlsx
 ```
-
-=======
->>>>>>> fcaa85b793ef9fe63d404ae58e13dba5b07d25c0


### PR DESCRIPTION
The README carried unresolved merge-conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) around the `### Usage` section — accidentally committed in the `eb2631f2` main merge (2025-01-24) and inherited by every branch off `main`. Removed the markers; kept the Usage section.

Trivial docs cleanup, no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)