### PR TITLE
Site-aware MC seeding: fix identical per-site parquet output (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 
 ## v0.4.0 (unreleased)
 
+### Bug Fixes (2026-06-03)
+
+- **SimRNG.py** / **SiteMain2.py** — site-aware MC seeding (issue #106). `runSim` seeded
+  every site's simulation with the MC run number alone, so two sites with identical study
+  definitions replayed bit-for-bit identical random streams and produced numerically
+  identical per-site `SiteSummary` output. The seed is now composed by
+  `SimRNG.composeSeed` as `[baseSeed?, crc32(siteName), mcRunNum]`: site identity
+  separates sites within a run, the MC run number keeps iterations distinct (#69), and
+  the optional `--randomSeed` base keeps whole-simulation reproducibility (#96).
+  **Default-mode results change for every site** (the seed composition changed) — this is
+  inherent to the fix, and re-runs remain deterministic.
+- **AppUtils.py** — ported the `-rs/--randomSeed` CLI flag from Curated_Root
+  (`ab45594`, issue #96): seed each MC run with `[randomSeed, …, mcRunNum]` when given;
+  unset → default seeding. Applied explicitly so a seed of `0` is not dropped by the
+  truthy CLI filter. The original commit's contract tests are not ported (they need
+  `Testing/OutputEquivalence`, which is not on this branch).
+
+### Tests (2026-06-03)
+
+- **test/test_issue106_site_seeding.py**: red-green coverage for #106. Fast tier — the
+  `composeSeed` contract (distinct per site, distinct per MC run, reproducible,
+  `--randomSeed` prepended, crc32 site key, legacy fallback). Slow tier (`-m slow`,
+  MAES conda env) — the canonical repro: two byte-identical study sheets run via
+  `--directory` must produce different `SiteSummary` numbers; a default rerun stays
+  bit-identical; `--randomSeed 42` shifts both sites without collapsing them. The `slow`
+  marker is now registered in `pyproject.toml`.
+
 ### Validation (2026-05-27)
 
 - **Testing/SummaryConsistency.py**: new directory-level consistency checker for a MAES

--- a/config/defaultConfig.json
+++ b/config/defaultConfig.json
@@ -16,6 +16,7 @@
     "defaultValues": {
       "inputRoot": "input",
       "outputRoot": "output",
+      "randomSeed": null,
       "scenarioTimestampFormat": "%Y%m%d_%H%M%S",
       "disableSimulation": false,
       "disableGraph": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,11 @@ python-semantic-release = "^9.16.0"
 mkdocs-material = "^9.5.49"
 python-semantic-release = "^9.15.2"
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: long-running engine integration tests (run in the MAES conda env)",
+]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/AppUtils.py
+++ b/src/AppUtils.py
@@ -52,6 +52,11 @@ def getParser(defaultConfig):
     parser.add_argument("-t",  "--testIntervalDays", help="simulation / serialization duration, days", type=int)
     parser.add_argument('-mc', '--monteCarloIterations', help="number of MC iterations", type=int)
     parser.add_argument('-r',  '--runNumber', help="scenario number", type=int)
+    parser.add_argument('-rs', '--randomSeed', type=int,
+                        help="Base RNG seed (non-negative). Combined with each MC run number "
+                             "as the seed sequence [randomSeed, mcRunNum], giving reproducible "
+                             "but per-run-distinct streams. Default (unset): seed each MC run "
+                             "with its run number (legacy behavior).")
 
     parser.add_argument("-ts", "--scenarioTimestamp", help="simulation / serialization identifier (timestamp)")
 
@@ -122,6 +127,11 @@ def getConfig(defaultConfig=DEFAULT_CONFIG, commandArgs=sys.argv[1:]):
 
     filteredCommandLineArgs = dict(filter(lambda x: x[1], args.__dict__.items()))
     cm.expandPhase("arguments", **filteredCommandLineArgs)
+
+    # randomSeed is applied explicitly because the truthy filter above would drop a
+    # legitimate seed of 0 (a common, valid seed). None means "unset" → legacy seeding.
+    if getattr(args, "randomSeed", None) is not None:
+        cm.expandPhase("defaultValues", randomSeed=args.randomSeed)
 
     # Process arguments out of the study definition file.
     # Exclude any keys already set by CLI args so the study file cannot override them.

--- a/src/SimRNG.py
+++ b/src/SimRNG.py
@@ -10,12 +10,33 @@ All simulation code draws from this module so that:
 
 Usage:
     import SimRNG
-    SimRNG.seed(mcRunNum)   # call once at the top of each MC iteration
+    SimRNG.seed(SimRNG.composeSeed(mcRunNum, siteName=siteName))  # top of each MC iteration
     x = SimRNG.random()     # scalar uniform draw on [0, 1)
 """
+import zlib
+
 import numpy as np
 
 _rng: np.random.Generator = np.random.default_rng()
+
+
+def composeSeed(mcRunNum, siteName=None, baseSeed=None) -> list:
+    """Build the seed material for one MC run: ``[baseSeed?, crc32(siteName)?, mcRunNum]``.
+
+    Site identity is mixed in so two sites with identical study definitions do
+    not replay the same stream within a run (CSU-METEC/MAES #106); the MC run
+    number keeps runs distinct per iteration (#69); the optional ``baseSeed``
+    (--randomSeed) prepends a user-chosen base so the whole simulation is
+    reproducible on demand and varies with the seed (#96). crc32 keeps the site
+    component stable across platforms and interpreter sessions (unlike hash()).
+    """
+    parts = []
+    if baseSeed is not None:
+        parts.append(int(baseSeed))
+    if siteName is not None:
+        parts.append(zlib.crc32(str(siteName).encode("utf-8")))
+    parts.append(int(mcRunNum))
+    return parts
 
 
 def seed(s=None) -> None:

--- a/src/SiteMain2.py
+++ b/src/SiteMain2.py
@@ -57,11 +57,13 @@ def initializeSim(config, simdm):
 
 def runSim(config, simdm):
     mcRunNum = config['MCScenario']
-    baseSeed = config.get('randomSeed')
-    # Legacy default (baseSeed is None): seed each MC run with its run number. When a base
-    # seed is supplied, seed with the sequence [baseSeed, mcRunNum] so runs stay distinct
-    # per MC iteration but the whole simulation is reproducible and varies with the seed.
-    SimRNG.seed(mcRunNum if baseSeed is None else [int(baseSeed), int(mcRunNum)])
+    # Seed = [baseSeed?, crc32(siteName), mcRunNum] (SimRNG.composeSeed): site identity
+    # keeps identical site definitions from replaying the same stream within a run
+    # (issue #106); mcRunNum keeps MC iterations distinct (#69); the optional
+    # --randomSeed base keeps the whole simulation reproducible on demand (#96).
+    SimRNG.seed(SimRNG.composeSeed(mcRunNum,
+                                   siteName=config.get('siteName'),
+                                   baseSeed=config.get('randomSeed')))
     with Timer(f"Run Simulation MC Iteration {mcRunNum}") as t0:
         with Timer("  Restore templates") as t1:
             simdm.restoreTemplates()

--- a/src/SiteMain2.py
+++ b/src/SiteMain2.py
@@ -57,7 +57,11 @@ def initializeSim(config, simdm):
 
 def runSim(config, simdm):
     mcRunNum = config['MCScenario']
-    SimRNG.seed(mcRunNum)
+    baseSeed = config.get('randomSeed')
+    # Legacy default (baseSeed is None): seed each MC run with its run number. When a base
+    # seed is supplied, seed with the sequence [baseSeed, mcRunNum] so runs stay distinct
+    # per MC iteration but the whole simulation is reproducible and varies with the seed.
+    SimRNG.seed(mcRunNum if baseSeed is None else [int(baseSeed), int(mcRunNum)])
     with Timer(f"Run Simulation MC Iteration {mcRunNum}") as t0:
         with Timer("  Restore templates") as t1:
             simdm.restoreTemplates()

--- a/test/test_issue106_site_seeding.py
+++ b/test/test_issue106_site_seeding.py
@@ -1,0 +1,218 @@
+"""Tests for GitHub issue CSU-METEC/MAES#106 — identical per-site parquet output.
+
+The bug: ``runSim`` seeds the simulation RNG from the MC run number alone
+(``SimRNG.seed(mcRunNum)``, introduced by the #69 RNG consolidation). The seed
+contains no site identity, so two sites with identical study definitions replay
+bit-for-bit identical random streams and produce numerically identical
+SiteSummary output — the reporter's symptom.
+
+The fix: compose the seed from ``[baseSeed?, crc32(siteName), mcRunNum]``
+(``SimRNG.composeSeed``). Site identity separates sites within a run; the MC
+run number keeps per-run distinctness; the optional ``--randomSeed`` base keeps
+whole-simulation reproducibility (#96).
+
+Two tiers:
+
+* Fast unit tests of the seed-composition contract (no engine).
+* One slow engine tier (``@pytest.mark.slow``) reproducing the issue exactly:
+  two byte-identical study sheets run via ``--directory``, asserting their
+  SiteSummary numbers differ, that a default rerun is bit-identical
+  (preserving #69's per-run determinism), and that ``--randomSeed`` shifts
+  both sites while keeping them distinct.
+
+Run the slow tier in the engine's runtime env (MAES conda env).
+"""
+
+import pathlib
+import shutil
+import subprocess
+import sys
+import zlib
+from dataclasses import dataclass
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent / "src"))
+
+import SimRNG
+
+MAES_ROOT = pathlib.Path(__file__).parent.parent
+SOURCE_STUDY = MAES_ROOT / "input/Studies/C3/C3_Prototypical_Sites/P1_1stage_noflare.xlsx"
+FIXTURE_SIM_DAYS = 7
+MC_ITERATIONS = 1
+
+
+# --------------------------------------------------------------------------- fast: seed contract
+
+def test_compose_seed_distinct_sites_distinct_seeds():
+    """Two sites at the same MC run must get different seed material (#106)."""
+    assert SimRNG.composeSeed(0, siteName="SiteA") != SimRNG.composeSeed(0, siteName="SiteB")
+
+
+def test_compose_seed_distinct_mc_runs_distinct_seeds():
+    """Same site, different MC runs must stay distinct (#69 contract)."""
+    assert SimRNG.composeSeed(0, siteName="SiteA") != SimRNG.composeSeed(1, siteName="SiteA")
+
+
+def test_compose_seed_deterministic():
+    """Same (site, mcRun, baseSeed) is reproducible across calls."""
+    assert SimRNG.composeSeed(3, siteName="X", baseSeed=42) == SimRNG.composeSeed(3, siteName="X", baseSeed=42)
+
+
+def test_compose_seed_base_seed_prepended():
+    """--randomSeed contributes a distinct leading component (#96), seed 0 included."""
+    noBase = SimRNG.composeSeed(1, siteName="X")
+    withBase = SimRNG.composeSeed(1, siteName="X", baseSeed=0)
+    assert withBase != noBase
+    assert withBase[0] == 0
+
+
+def test_compose_seed_site_key_is_crc32():
+    """Site component is crc32 of the site name — stable across platforms/runs."""
+    seed = SimRNG.composeSeed(5, siteName="SiteA")
+    assert seed == [zlib.crc32(b"SiteA"), 5]
+
+
+def test_compose_seed_legacy_without_site():
+    """No site, no base seed → just the MC run number (legacy #69 behavior)."""
+    assert SimRNG.composeSeed(7) == [7]
+
+
+def test_streams_differ_between_sites():
+    """End-to-end through the generator: identical draws were the #106 bug."""
+    SimRNG.seed(SimRNG.composeSeed(0, siteName="SiteA"))
+    drawsA = list(map(lambda _: SimRNG.random(), range(100)))
+    SimRNG.seed(SimRNG.composeSeed(0, siteName="SiteB"))
+    drawsB = list(map(lambda _: SimRNG.random(), range(100)))
+    assert drawsA != drawsB
+
+
+# --------------------------------------------------------------------------- slow: engine repro
+
+@dataclass
+class EngineRun:
+    siteA: pd.DataFrame
+    siteB: pd.DataFrame
+
+
+def _makeFixtureSheets(studiesDir: pathlib.Path) -> None:
+    """Write SiteA.xlsx / SiteB.xlsx — byte-identical short-duration copies of P1.
+
+    P1's only formula cells (three ``=76.68…/10`` constants on Cycling Wells) are
+    materialized to literals: openpyxl does not carry cached formula results, so
+    a resave would otherwise leave NaNs where the engine expects numbers.
+    """
+    import openpyxl
+
+    wb = openpyxl.load_workbook(SOURCE_STUDY)
+    for ws in wb.worksheets:
+        for row in ws.iter_rows():
+            for cell in row:
+                if cell.data_type == "f":
+                    expr = cell.value.lstrip("=")
+                    num, denom = expr.split("/")
+                    cell.value = float(num) / float(denom)
+    params = wb["Global Simulation Parameters"]
+    for row in params.iter_rows(min_col=1, max_col=2):
+        if row[0].value == "Simulation Duration [Days]":
+            row[1].value = FIXTURE_SIM_DAYS
+    siteA = studiesDir / "SiteA.xlsx"
+    wb.save(siteA)
+    shutil.copyfile(siteA, studiesDir / "SiteB.xlsx")
+
+
+def _makeInputRoot(tmpRoot: pathlib.Path) -> pathlib.Path:
+    """Build an inputRoot whose Studies/ holds only the fixture pair.
+
+    CuratedData and ModelFormulation are symlinked from the repo when possible
+    (Linux/mac), copied otherwise (Windows without symlink privilege).
+    """
+    inputRoot = tmpRoot / "input"
+    studiesDir = inputRoot / "Studies" / "Issue106"
+    studiesDir.mkdir(parents=True)
+    for sub in ("CuratedData", "ModelFormulation"):
+        src, dst = MAES_ROOT / "input" / sub, inputRoot / sub
+        try:
+            dst.symlink_to(src, target_is_directory=True)
+        except OSError:
+            shutil.copytree(src, dst)
+    _makeFixtureSheets(studiesDir)
+    return inputRoot
+
+
+def _runEngine(inputRoot: pathlib.Path, outDir: pathlib.Path, seed=None) -> EngineRun:
+    """Run the two-site study; return each site's SiteSummary (site column dropped)."""
+    outDir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable, "src/SiteMain2.py",
+        "-i", str(inputRoot),
+        "-or", str(outDir),
+        "-dr", "Issue106",
+        # getConfig reads the -s study for global params even in -dr mode, and the
+        # default (MEET2/ConstantSeparator.xlsx) does not exist in this inputRoot.
+        "-s", "Issue106/SiteA.xlsx",
+        "-mc", str(MC_ITERATIONS),
+    ]
+    if seed is not None:
+        cmd += ["-rs", str(seed)]
+    r = subprocess.run(cmd, cwd=MAES_ROOT, capture_output=True, text=True, timeout=1800)
+    assert r.returncode == 0, f"engine failed (seed={seed}).\nSTDOUT:\n{r.stdout}\nSTDERR:\n{r.stderr}"
+
+    datasets = list(filter(lambda d: d.is_dir(), outDir.rglob("SiteSummary")))
+    assert len(datasets) == 1, f"expected one SiteSummary dataset under {outDir}, found {datasets}"
+    return EngineRun(
+        siteA=_loadSite(datasets[0], "SiteA"),
+        siteB=_loadSite(datasets[0], "SiteB"),
+    )
+
+
+def _loadSite(dataset: pathlib.Path, site: str) -> pd.DataFrame:
+    df = pd.read_parquet(dataset, filters=[("site", "=", site)])
+    assert not df.empty, f"no SiteSummary rows for {site}"
+    sortCols = list(filter(lambda c: df[c].dtype == object and c != "readings", df.columns))
+    return (df.drop(columns=["site", "readings"], errors="ignore")
+              .sort_values(sortCols)
+              .reset_index(drop=True))
+
+
+def _framesEqual(a: pd.DataFrame, b: pd.DataFrame) -> bool:
+    return a.shape == b.shape and a.equals(b)
+
+
+@pytest.fixture(scope="module")
+def engineRuns(tmp_path_factory):
+    tmpRoot = tmp_path_factory.mktemp("issue106")
+    inputRoot = _makeInputRoot(tmpRoot)
+    return {
+        "default": _runEngine(inputRoot, tmpRoot / "out_default"),
+        "default_repeat": _runEngine(inputRoot, tmpRoot / "out_default_repeat"),
+        "seed42": _runEngine(inputRoot, tmpRoot / "out_seed42", seed=42),
+    }
+
+
+@pytest.mark.slow
+def test_identical_sites_produce_distinct_output(engineRuns):
+    """THE #106 regression: byte-identical sheets must not yield identical numbers."""
+    run = engineRuns["default"]
+    assert not _framesEqual(run.siteA, run.siteB), (
+        "SiteA and SiteB SiteSummary outputs are numerically identical — "
+        "the RNG seed contains no site identity (CSU-METEC/MAES#106)"
+    )
+
+
+@pytest.mark.slow
+def test_default_rerun_is_deterministic(engineRuns):
+    """#69's contract survives the fix: same inputs, same seeds → identical output."""
+    first, second = engineRuns["default"], engineRuns["default_repeat"]
+    assert _framesEqual(first.siteA, second.siteA)
+    assert _framesEqual(first.siteB, second.siteB)
+
+
+@pytest.mark.slow
+def test_random_seed_shifts_both_sites_and_keeps_them_distinct(engineRuns):
+    """--randomSeed (#96) composes with site identity instead of replacing it."""
+    default, seeded = engineRuns["default"], engineRuns["seed42"]
+    assert not _framesEqual(seeded.siteA, seeded.siteB)
+    assert not _framesEqual(default.siteA, seeded.siteA)
+    assert not _framesEqual(default.siteB, seeded.siteB)


### PR DESCRIPTION
## Summary

Fixes #106 — identical parquet output for multiple sites on Summary_Rewrite.

**Root cause:** since the #69 RNG consolidation (merged 2026-05-24), `runSim` seeds the simulation RNG with the MC run number alone (`SimRNG.seed(mcRunNum)`). The seed contains no site identity, so two sites with identical study definitions replay bit-for-bit identical random streams and produce numerically identical `SiteSummary` output. Verified by repro: two byte-identical copies of `P3_2stages_VRU.xlsx` produced 1306 bit-identical SiteSummary rows on Summary_Rewrite tip, while the commit immediately before the #69 merge (`989ba61`) produced divergent results (1380 vs 1142 rows).

**Fix:** the per-run seed is now composed by `SimRNG.composeSeed` as `[baseSeed?, crc32(siteName), mcRunNum]`:
- site identity separates sites within a run (**#106**)
- the MC run number keeps iterations distinct (**#69**, preserved)
- the optional `--randomSeed` base keeps whole-simulation reproducibility (**#96**)

## Commits (red-green)

1. `c5dcf38` — code-only port of Curated_Root's `ab45594` (`-rs/--randomSeed` flag, #96). Its contract tests are **not** ported: they depend on `Testing/OutputEquivalence`, which doesn't exist on Summary_Rewrite. *Merge note:* when Curated_Root eventually lands, the ported hunks are content-identical except the `runSim` seed line, where this branch's version is the superset — resolve by taking this side.
2. `0c4fb0a` — tests. **Red at this commit:** `test_identical_sites_produce_distinct_output` and `test_random_seed_shifts_both_sites_and_keeps_them_distinct` FAIL (sites numerically identical, with or without `-rs`); `test_default_rerun_is_deterministic` passes (determinism was never broken).
3. `35778e5` — the fix. **Green:** all 10 tests pass (7 fast seed-contract + 3 slow engine tests, 25 s in the MAES conda env). Remaining suite: 70 passed, 0 failures.

## Tests

- **Fast tier** (no engine): `composeSeed` contract — distinct per site, distinct per MC run, reproducible, `--randomSeed` prepended (seed 0 included), crc32 site key, legacy fallback.
- **Slow tier** (`-m slow`): the canonical repro — two byte-identical 7-day study sheets run via `--directory`; asserts per-site SiteSummary numbers differ, a default rerun is bit-identical, and `--randomSeed 42` shifts both sites while keeping them distinct.

## Behavior change

Default-mode results change for **every** site (the seed composition changed). This is inherent to the fix; re-runs remain deterministic. Renaming a site now changes its draws (site name is part of the seed) — considered acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)