### PR TITLE
Port parallelism-improvements onto Site_Definition_Cleanup (thread-caps + equipment-table buffering)

### DIFF
--- a/src/EquipmentTable.py
+++ b/src/EquipmentTable.py
@@ -328,15 +328,51 @@ class EquipmentTable(ABC):
 class JsonEquipmentTable(EquipmentTable):
 
     def __init__(self, eqAttributes=None, eqMap=None):
+        self._pendingRows = []
         if eqAttributes is not None:
-            self.equipmentAttributes = eqAttributes
+            self._equipmentAttributes = eqAttributes
         else:
-            self.equipmentAttributes = pd.DataFrame(columns=EquipmentTableEntry.EQUIPMENT_TABLE_FIELDS)
+            self._equipmentAttributes = pd.DataFrame(columns=EquipmentTableEntry.EQUIPMENT_TABLE_FIELDS)
 
         if eqMap is not None:
             self.equipmentMap = eqMap
         else:
             self.equipmentMap = {}  # we want this to be name -> EquipmentTableEntry
+
+    # equipmentAttributes is read by many callers (getMetadata, getEquipment,
+    # tablesForMCRun, MEETSimSummary, ModelFormulation). Per-row appends are
+    # buffered in self._pendingRows and the DataFrame is built only when something
+    # reads, turning the previous O(N^2) per-row concat into O(N).
+    @property
+    def equipmentAttributes(self):
+        if self._pendingRows:
+            # dtype=object keeps each value's original Python type. Without it,
+            # a key column mixing ints with None is coerced to float64, turning
+            # 12345 into 12345.0 -> "12345.0" in metadata.csv while the event
+            # logger writes "12345", so the metadata<->events merge misses every
+            # row and downstream groupby drops them all. dtype=object reproduces
+            # the original empty-seed-then-concat behavior exactly.
+            new = pd.DataFrame(
+                self._pendingRows,
+                columns=EquipmentTableEntry.EQUIPMENT_TABLE_FIELDS,
+                dtype=object,
+            )
+            self._pendingRows = []
+            # Defense-in-depth: a blank study-sheet cell read as NaN would break
+            # equipmentMap tuple-key lookups (NaN != NaN).
+            for col in ('facilityID', 'unitID', 'emitterID', 'mcRunNum'):
+                if new[col].isna().any():
+                    new = new.assign(**{col: new[col].where(new[col].notna(), None)})
+            if self._equipmentAttributes.empty:
+                self._equipmentAttributes = new
+            else:
+                self._equipmentAttributes = pd.concat([self._equipmentAttributes, new], ignore_index=True)
+        return self._equipmentAttributes
+
+    @equipmentAttributes.setter
+    def equipmentAttributes(self, value):
+        self._pendingRows = []
+        self._equipmentAttributes = value
 
     class FakeInstance:
         def __init__(self, facilityID, unitID, emitterID, mcRunNum):
@@ -352,7 +388,8 @@ class JsonEquipmentTable(EquipmentTable):
         return self.getEquipment(mcRunNum=-1)
 
     def getEquipment(self, mcRunNum=None):
-        tmpls = self.equipmentAttributes[self.equipmentAttributes['mcRunNum'] == mcRunNum]
+        attrs = self.equipmentAttributes
+        tmpls = attrs[attrs['mcRunNum'] == mcRunNum]
         tmplKeys = tmpls.apply(self._instanceKey, axis='columns')
         ret = list(map(lambda x: self.equipmentMap[x], tmplKeys))
         return ret
@@ -373,14 +410,14 @@ class JsonEquipmentTable(EquipmentTable):
         return ret
 
     def addEquipment(self, instance):
-        instDict = filterDict(instance.__dict__, EquipmentTableEntry.EQUIPMENT_TABLE_FIELDS)
-        self.equipmentAttributes = pd.concat([self.equipmentAttributes, pd.DataFrame(instDict, index=[0])])
         key = self._instanceKey(instance)
         if key in self.equipmentMap:
             prevInstance = self.equipmentMap[key]
             msg = f"Duplicate equipment key: {key}, previous instance: {prevInstance}"
             logging.error(msg)
             raise me.IllegalElementError(msg)
+        instDict = filterDict(instance.__dict__, EquipmentTableEntry.EQUIPMENT_TABLE_FIELDS)
+        self._pendingRows.append(instDict)
         self.equipmentMap[key] = instance
 
     def elementLookup(self, facilityID, unitID=None, emitterID=None, mcRunNum=-1):
@@ -388,11 +425,12 @@ class JsonEquipmentTable(EquipmentTable):
         return self.equipmentMap.get(key, None)
 
     def tablesForMCRun(self, mcRunNum=None):
+        attrs = self.equipmentAttributes
         if mcRunNum is None:
-            mdToDump = self.equipmentAttributes
+            mdToDump = attrs
             equipmentToDump = self.equipmentMap
         else:
-            mdToDump = self.equipmentAttributes[self.equipmentAttributes['mcRunNum'] == mcRunNum]
+            mdToDump = attrs[attrs['mcRunNum'] == mcRunNum]
             equipmentToDump = self.getEquipment(mcRunNum)
 
         return mdToDump, equipmentToDump

--- a/src/ParquetMain.py
+++ b/src/ParquetMain.py
@@ -1,3 +1,11 @@
+import os
+# Cap BLAS / OpenMP thread counts to 1 BEFORE pandas/numpy/pyarrow load (GraphUtils
+# below imports pandas). Forked workers inherit these caps instead of each spawning
+# N threads and oversubscribing the host. Must stay above every other import here.
+for envVar in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+               "BLIS_NUM_THREADS", "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(envVar, "1")
+
 import GraphUtils as gu
 import AppUtils as au
 import logging

--- a/src/SiteMain2.py
+++ b/src/SiteMain2.py
@@ -1,3 +1,12 @@
+import os
+# Cap BLAS / OpenMP / pyarrow thread counts to 1 BEFORE pandas/numpy/pyarrow are
+# imported below. Each forked Pool worker otherwise inherits an uncapped pool and
+# spawns N threads, oversubscribing the host on many-worker runs. Must stay above
+# every other import in this module.
+for envVar in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+               "BLIS_NUM_THREADS", "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(envVar, "1")
+
 import AppUtils as au
 import ModelFormulation as mf
 import logging
@@ -13,7 +22,6 @@ import functools
 import utilities.EmissionsCSVGenerator as eg
 import Units as u
 import ParquetLib as pl
-import os
 import pandas as pd
 import datetime as dt
 import Summaries2 as sum
@@ -290,9 +298,25 @@ def configFromConfigMgr(cMgr):
     return config
 
 def initWorker(base: dict) -> None:
-    """Set the shared workitem base dict in each Pool worker process."""
+    """Set the shared workitem base dict in each Pool worker, and cap this
+    worker's BLAS/pyarrow thread pools to 1.
+
+    The env caps are also set at module import and inherited via fork, but a
+    worker started under the 'spawn' start method re-imports fresh, so they are
+    reasserted here. pyarrow's own thread pools are not env-driven, so they are
+    pinned explicitly.
+    """
     global workerBase
     workerBase = base
+    for envVar in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+                   "BLIS_NUM_THREADS", "NUMEXPR_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+        os.environ.setdefault(envVar, "1")
+    try:
+        import pyarrow as pa
+        pa.set_cpu_count(1)
+        pa.set_io_thread_count(1)
+    except Exception:
+        pass
 
 
 def makeSlimWorkitem(base: dict, workitem: dict) -> dict:
@@ -356,7 +380,13 @@ def instEmissionsRowCount(wi: dict) -> int:
 def runMultiprocessing(workQueue, workers):
     import multiprocessing as mp
     workType = workQueue[0].get('workType', 'UNKNOWN') if workQueue else 'UNKNOWN'
-    logger.info(f"multiprocessing w/ work type: {workType}, workers: {workers}")
+    nItems = len(workQueue)
+    # Don't spin up more workers than there are workitems (matters for single-item phases).
+    if nItems > 0:
+        effectiveWorkers = max(1, min(workers, nItems))
+    else:
+        effectiveWorkers = workers
+    logger.info(f"multiprocessing w/ work type: {workType}, workers: {effectiveWorkers}, items: {nItems}")
     if workType == 'createPDFCache':
         # createPDFCache runs after the parquet phase, which writes InstEmissions parquet
         # files to parquetNewInstEmissions. Those files already exist on disk here, so
@@ -370,7 +400,7 @@ def runMultiprocessing(workQueue, workers):
         # to the OS, so without this, worker RSS grows monotonically across sequential mc
         # runs within a process. For N5+ workloads this exhausts physical RAM + swap before
         # the pool closes. The fork cost (~50-100 ms) is negligible vs simulation run times.
-        with mp.Pool(workers, initializer=initWorker, initargs=(base,),
+        with mp.Pool(effectiveWorkers, initializer=initWorker, initargs=(base,),
                      maxtasksperchild=1) as p:
             res = list(p.imap_unordered(runWorkitemSlim, slimQueue))
         t0.setCount(len(res))


### PR DESCRIPTION
## What this does

Ports the portions of Ethan Rimmelman's `parallelism-improvements` (@`3bc33d4`) that fit `Site_Definition_Cleanup`, adapted to its architecture and to TeamClaude CodingStandards. `parallelism-improvements` is based on `main`, which diverged from S_D_C before S_D_C grew its own parallelism / summary-rewrite layer — so this is a reconciliation, not a straight cherry-pick. Full decision record: #110.

## Ported

- **`fix: cap BLAS/pyarrow threads to fix multiprocessing oversubscription`** (`7ba16d6`)
  - Module-import-time BLAS/OpenMP env caps in the `SiteMain2` and `ParquetMain` entry points (set before pandas/numpy/pyarrow import, so forked Pool workers inherit a capped pool instead of each spawning N threads).
  - Reinforced in S_D_C's existing `initWorker` (reasserts env caps for the spawn start method; pins pyarrow cpu/io thread counts, which are not env-driven). Folded in rather than adding a separate initializer.
  - `runMultiprocessing` caps `effectiveWorkers = min(workers, nItems)`.
- **`perf: buffer equipment-table appends to eliminate O(N^2) concat`** (`0f679f3`)
  - `JsonEquipmentTable` per-row `pd.concat` replaced with a `_pendingRows` buffer; the DataFrame is built lazily via the `equipmentAttributes` property on first read.
  - `dtype=object` prevents integer key columns being coerced to float64 (which broke the metadata↔events merge); NaN→None cleanup on key columns; dup-key guard now runs before buffering.

## Intentionally NOT ported (omissions leave no diff — recorded here and in #110)

- **PDF compute `toPDF` fix** — Ethan's premise (`TimeseriesSet` has no `toPDF`) holds on `main`, but S_D_C added `TimeseriesSet.toPDF` (`Timeseries.py:1231`) and the live pipeline already uses it (`Summaries2.py:788,823`). His change also lands in `Summaries.py`, which is runtime-dead on S_D_C (#109). **S_D_C wins; dropped.**
- **Cross-worker dedup for sim-wide aggregation** — S_D_C moved sim-wide aggregation into a dedicated single-item phase (`simSummary`/`computeSimSummary`) that runs once in the main process via `runLocal`, so the duplicate-across-workers race Ethan's filesystem-claim guards cannot occur by construction. **Unnecessary; dropped.**
- **`chunksize` tuning** — conflicts with S_D_C's `maxtasksperchild=1` RSS fix (chunksize > 1 lets a worker process multiple items before recycling). **Dropped.**

## Deferred

- **`CombineMain.py`** (Ethan's `3bc33d4`) is effectively a new S_D_C-native tool: it targets `main`'s CSV summary layout, the dead `Summaries.py` pipelines, and an `abnormal` ON/OFF summary axis that doesn't exist in S_D_C's live pipeline. Deferred with a verified design spec → **#111**.

## Verification (in the `MAES` conda env)

- Import smoke: `EquipmentTable`, `ParquetMain`, `SiteMain2` import cleanly.
- `test_EmitterTestv2` 9 passed (exercises the new `equipmentAttributes` property); `test_StatisticalTest` + `test_Summaries2` 9 passed.
- Functional: module-import thread caps applied; `initWorker` sets `workerBase` and pins pyarrow cpu/io to 1.
- Not exercised end-to-end: `runMultiprocessing`'s `effectiveWorkers` path (needs real workitems + a Pool) — logic + syntax/import verified only.

Closes #110. Refs #109, #111.

cc @rimelman

🤖 Generated with [Claude Code](https://claude.com/claude-code)
