### PR TITLE
Fix N×-site over-count in SimSummary/SimPDF (#114)

### DIFF
--- a/src/SiteMain2.py
+++ b/src/SiteMain2.py
@@ -182,9 +182,12 @@ def generateWorkitems(cm, phasesToInclude=ALL_PHASES):
     createPDFCacheWorkitems = []
     simSummaryWorkitems = []
 
-    # The per-site SiteSummary/PDF output dirs, accumulated as each site's config
-    # is expanded. The single simSummary workitem aggregates across all of these,
-    # rather than seeing only the last site left in the config manager.
+    # The SiteSummary/PDF datasets are single shared, hive-partitioned-by-site
+    # directories (their config paths carry no {site} component), so every site in
+    # the loop resolves the SAME path. Add each distinct directory exactly once; the
+    # simSummary workitem then reads each shared dataset once and recovers `site` from
+    # the partition. Appending per-site would read the whole dataset N times and inflate
+    # every SimSummary/SimPDF level by the site count (issue #114).
     allSiteSummaryDirs = []
     allSitePDFDirs = []
 
@@ -206,8 +209,12 @@ def generateWorkitems(cm, phasesToInclude=ALL_PHASES):
         summaryWI = generateSingleWorkitem(cm, 'summarize')
         summaryWorkitems.append(summaryWI)
         createPDFCacheWorkitems.append(generateSingleWorkitem(cm, 'createPDFCache'))
-        allSiteSummaryDirs.append(cm.getConfigVar('parquetNewSummary'))
-        allSitePDFDirs.append(cm.getConfigVar('parquetNewPDF'))
+        summaryDir = cm.getConfigVar('parquetNewSummary')
+        if summaryDir not in allSiteSummaryDirs:
+            allSiteSummaryDirs.append(summaryDir)
+        pdfDir = cm.getConfigVar('parquetNewPDF')
+        if pdfDir not in allSitePDFDirs:
+            allSitePDFDirs.append(pdfDir)
     # simSummary happens once per simulation, aggregating every site's summaries
     simSummaryWI = generateSingleWorkitem(cm, 'simSummary')
     simSummaryWI['allSiteSummaryDirs'] = allSiteSummaryDirs

--- a/test/test_issue114_sim_dir_dedup.py
+++ b/test/test_issue114_sim_dir_dedup.py
@@ -1,0 +1,163 @@
+"""Tests for GitHub issue CSU-METEC/MAES#114 — SimSummary/SimPDF over-count by site count.
+
+The bug: ``generateWorkitems`` builds ``allSiteSummaryDirs`` / ``allSitePDFDirs`` by
+appending ``parquetNewSummary`` / ``parquetNewPDF`` once **per site**. Those paths carry
+no ``{site}`` component (``parquetDir`` is keyed by ``studyName`` + ``scenarioTimestamp``,
+constant across the multi-site loop) — the per-site rows live inside one shared dataset,
+hive-partitioned by ``site``. So each list ends up as N **identical** paths, and
+``_readSummaryAcrossSites`` reads the one shared all-sites dataset N times and concatenates
+→ every ``SimSummary`` / ``SimPDF`` level is inflated by exactly the site count.
+
+Reproduced (5-site run): ``SimSummary`` modelReadableName total = 5.0x the true cross-site
+total; ``SimPDF`` mixture probability sums to 5.0 instead of 1.0.
+
+Why the #101 tests missed it: their fixtures wrote each site to a *distinct* directory
+(``base/<site>/SiteSummary``) and built the dir lists from those, a layout the engine never
+produces. These tests drive the real ``generateWorkitems`` construction against the real
+``defaultConfig`` path templates instead.
+
+The fix: in ``generateWorkitems``, add each distinct dataset directory to the list exactly
+once (the shared dataset is read once; ``site`` is recovered from the hive partition).
+"""
+
+import json
+import os
+
+import pytest
+
+import SiteMain2
+from ConfigManager import ConfigManager
+import pandas as pd
+from Summaries2 import summarizeSimulation
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), '..', 'config', 'defaultConfig.json')
+
+
+def _setupConfigManager(tmpOutputRoot):
+    """Initialize the ConfigManager singleton from the real defaultConfig and expand
+    phases in the same dependency order ``AppUtils.getConfig`` uses, so that
+    ``parquetNewSummary`` / ``parquetNewPDF`` resolve through the real templates to the
+    single shared (studyName + scenarioTimestamp keyed) dataset path the engine emits."""
+    with open(CONFIG_PATH) as cf:
+        config = json.load(cf)
+    ConfigManager._initializeSingleton(config)
+    ConfigManager.expandPhase('defaultValues')
+    ConfigManager.expandPhase('arguments', studyName='run', studyDefinitionFile='seed.xlsx',
+                              monteCarloIterations=1, outputRoot=str(tmpOutputRoot))
+    ConfigManager.expandPhase('start', site='run', scenarioTimestamp='TS')
+    ConfigManager.expandPhase('simulation')
+    return ConfigManager
+
+
+def _simSummaryWorkitem(cm, monkeypatch, siteNames):
+    """Drive the real generateWorkitems over ``siteNames`` (stubbing only the on-disk
+    study discovery in getFileList) and return the single simSummary workitem."""
+    fileList = list(map(lambda s: (f'{s}.xlsx', f'{s}.xlsx', s), siteNames))
+    monkeypatch.setattr(SiteMain2, 'getFileList', lambda _cm: iter(fileList))
+    workitemGroups = SiteMain2.generateWorkitems(cm, phasesToInclude=['simSummary'])
+    return workitemGroups[0][0]
+
+
+def test_site_summary_dirs_have_no_per_site_duplicates(tmp_path, monkeypatch):
+    cm = _setupConfigManager(tmp_path)
+    wi = _simSummaryWorkitem(cm, monkeypatch, ['siteA', 'siteB', 'siteC'])
+
+    dirs = wi['allSiteSummaryDirs']
+    assert dirs, "simSummary workitem must carry the site summary dirs"
+    assert dirs == list(dict.fromkeys(dirs)), (
+        f"allSiteSummaryDirs must add each distinct dataset dir once; got {len(dirs)} "
+        f"entries with {len(set(dirs))} unique -> the shared dataset would be read "
+        f"{len(dirs)}x (={len(dirs)}x-site inflation): {dirs}")
+
+
+def test_site_pdf_dirs_have_no_per_site_duplicates(tmp_path, monkeypatch):
+    cm = _setupConfigManager(tmp_path)
+    wi = _simSummaryWorkitem(cm, monkeypatch, ['siteA', 'siteB', 'siteC'])
+
+    dirs = wi['allSitePDFDirs']
+    assert dirs, "simSummary workitem must carry the site PDF dirs"
+    assert dirs == list(dict.fromkeys(dirs)), (
+        f"allSitePDFDirs must add each distinct dataset dir once; got {len(dirs)} "
+        f"entries with {len(set(dirs))} unique -> SimPDF mixture inflated "
+        f"{len(dirs)}x: {dirs}")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end invariants (#27): the simulation-level value is the cross-site sum.
+# Fixtures use the REAL shared-dir layout (ONE directory, hive-partitioned by
+# site) that the engine actually emits -- not the per-site distinct dirs the
+# #101 tests used -- so an N-identical-paths regression inflates them N-fold.
+# ---------------------------------------------------------------------------
+
+MC_ITERATIONS = 2
+
+
+def _writeSharedSiteSummary(summaryDir, siteReadings, modelReadableName='src1'):
+    """Write ONE shared SiteSummary dataset (single dir, hive-partitioned by site)
+    with a COMBINED modelEmissionCategory + modelReadableName row per site, each
+    carrying a per-MC-run ``readings`` list. Mirrors the engine's on-disk layout."""
+    rows = list(map(lambda kv: {
+        'species': 'METHANE', 'units': 'mt/year', 'includeFugitive': False,
+        'CICategory': 'modelReadableName', 'modelEmissionCategory': 'COMBINED',
+        'modelReadableName': modelReadableName, 'unitID': 'u1', 'METype': 'mt1',
+        'pneumatic': 'none', 'readings': list(map(float, kv[1])),
+        'mean': float(sum(kv[1])) / MC_ITERATIONS, 'site': kv[0],
+    }, siteReadings.items()))
+    pd.DataFrame(rows).to_parquet(summaryDir, partition_cols=['site'], index=False)
+
+
+def _writeSharedSitePDF(pdfDir, siteRates):
+    """Write ONE shared site-PDF dataset (single dir, partitioned by site); one
+    siteTotals component per site so nComponents == number of sites."""
+    rows = list(map(lambda kv: {
+        'species': 'METHANE', 'includeFugitive': False, 'CICategory': 'siteTotals',
+        'site': kv[0], 'operator': 'op', 'psno': kv[0],
+        'emissionRate_kgPerH': float(kv[1]), 'probability': 1.0,
+    }, siteRates.items()))
+    pd.DataFrame(rows).to_parquet(pdfDir, partition_cols=['site'], index=False)
+
+
+def _runSimSummary(tmp_path, monkeypatch, siteReadings, siteRates):
+    """Drive the real generateWorkitems construction + summarizeSimulation against
+    shared-dir fixtures written to the engine-resolved paths. Returns the workitem."""
+    cm = _setupConfigManager(tmp_path)
+    _writeSharedSiteSummary(cm.getConfigVar('parquetNewSummary'), siteReadings)
+    _writeSharedSitePDF(cm.getConfigVar('parquetNewPDF'), siteRates)
+    wi = _simSummaryWorkitem(cm, monkeypatch, list(siteReadings))
+    wi['monteCarloIterations'] = MC_ITERATIONS
+    summarizeSimulation(wi)  # writes SimSummary, then createSimPDF
+    return wi
+
+
+def test_simsummary_total_equals_sum_over_sites(tmp_path, monkeypatch):
+    siteReadings = {'siteA': [2.0, 2.0], 'siteB': [3.0, 3.0], 'siteC': [5.0, 5.0]}
+    siteRates = {'siteA': 10.0, 'siteB': 20.0, 'siteC': 30.0}
+    wi = _runSimSummary(tmp_path, monkeypatch, siteReadings, siteRates)
+
+    sim = pd.read_parquet(wi['parquetNewSimSummary'])
+    row = sim[(sim['CICategory'] == 'modelReadableName')
+              & (sim['modelReadableName'] == 'src1') & (sim['species'] == 'METHANE')]
+    simTotal = row['total'].sum()
+    expected = sum(map(sum, siteReadings.values()))  # 4 + 6 + 10 = 20
+
+    assert abs(simTotal - expected) < 1e-9, (
+        f"SimSummary modelReadableName total must equal the sum over sites (#27): "
+        f"got {simTotal}, expected {expected} "
+        f"({len(siteReadings)}x-site inflation would give {expected * len(siteReadings)})")
+
+
+def test_simpdf_mixture_mass_not_inflated(tmp_path, monkeypatch):
+    siteReadings = {'siteA': [2.0, 2.0], 'siteB': [3.0, 3.0], 'siteC': [5.0, 5.0]}
+    siteRates = {'siteA': 10.0, 'siteB': 20.0, 'siteC': 30.0}
+    wi = _runSimSummary(tmp_path, monkeypatch, siteReadings, siteRates)
+
+    simpdf = pd.read_parquet(wi['parquetNewSimPDF'])
+    assert not simpdf.empty, "SimPDF must be produced"
+    # A mixture distribution's probability mass is at most 1.0 per identity group.
+    # (Per #94 it may sum to <1.0 for transient sources -- a separate open bug --
+    # so we assert <= 1.0 rather than == 1.0; the N-identical-paths bug makes it
+    # equal the site count, here 3.0, which this catches.)
+    massPerGroup = simpdf.groupby(['species', 'includeFugitive'], observed=True)['probability'].sum()
+    assert massPerGroup.max() <= 1.0 + 1e-9, (
+        f"SimPDF mixture mass must not exceed 1.0; got max {massPerGroup.max()} "
+        f"({len(siteReadings)}x-site inflation would give {len(siteReadings)}.0)")


### PR DESCRIPTION
Fixes the SimSummary/SimPDF over-count reported in #114 (Jenna's 5-site run showed ~5× inflated means vs `main` and an earlier branch build).

## Root cause
`generateWorkitems` built `allSiteSummaryDirs` / `allSitePDFDirs` by appending `parquetNewSummary` / `parquetNewPDF` **once per site**. Those paths carry no `{site}` component — each is a single shared dataset, hive-partitioned by `site` — so the lists became **N identical paths**, and `_readSummaryAcrossSites` read the one all-sites dataset **N times** and concatenated, inflating every `SimSummary` / `SimPDF` level by the site count. Introduced by #101 (`7bdf716`): the per-site dir threading assumed one directory per site, which doesn't match the shared partitioned-by-site storage model. It shipped because the #101 fixtures used *distinct* per-site dirs the engine never emits (a false green).

## Fix
In `generateWorkitems`, add each **distinct** dataset directory to the list exactly once (no append-per-site, no dedupe pass). The shared dataset is read once and `site` is recovered from the hive partition. One change fixes **both** SimSummary and SimPDF.

## Tests — `test/test_issue114_sim_dir_dedup.py` (all verified red→green; 32 related summary tests still pass)
- **construction:** `allSiteSummaryDirs` / `allSitePDFDirs` contain no per-site duplicates — drives the real `generateWorkitems` against the real `defaultConfig` templates (the real shared-dir layout, unlike the #101 fixtures).
- **end-to-end invariant (#27):** `SimSummary` modelReadableName total == Σ-over-sites of `SiteSummary` total; `SimPDF` mixture mass ≤ 1.0 (≤, not ==, to stay robust to #94).

## End-to-end engine confirmation
Re-ran the original 5-site reproduction on the fixed code:

| metric | before | after |
|---|--:|--:|
| `SimSummary` total ÷ Σ-over-sites | 5.0000 | **1.0000** |
| `SimPDF` mixture mass (max per group) | 5.0 | **≤ 1.0** |

## Related
- #27 — this was a concrete violation of its cross-site-sum invariant.
- #64 — a systematic invariant-oracle (enforce the #27 identity across all levels in CI) is scoped there; these per-bug tests are the seed.
- #94 — `SimPDF` mass < 1.0 for transient sources is a **separate** open bug, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
