### PR TITLE
Vectorize PDF-cascade hot paths (#121): 3.7x on PDF phases, row-identical outputs; pdfCoalesce + pdfSpecies gates

### DIFF
--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -741,7 +741,15 @@ def _buildCoarseCacheLevel(fineDF, groupCols, levelName, binSize=1e-6, coalesce=
         colVals = []
         for groupKey in groupKeysList:
             colVals.append(groupKey[colIdx])
-        colArrays[col] = np.repeat(np.array(colVals), groupSizes)
+        keyArr = np.asarray(colVals)
+        if keyArr.dtype.kind in ('U', 'S'):
+            # String identity values: repeat an OBJECT-dtype array so np.repeat copies
+            # references to the per-group Python strings (matching the memory behaviour of the
+            # old [value] * n lists, where all n rows shared one string object). A fixed-width
+            # '<U' array here would materialise a separate string per row on conversion to the
+            # frame's object column — measured as ~+26% tree peak RSS on the mc=100 workload.
+            keyArr = np.array(colVals, dtype=object)
+        colArrays[col] = np.repeat(keyArr, groupSizes)
     colArrays['startTime_s'] = np.concatenate(startsOut)
     colArrays['endTime_s'] = np.concatenate(endsOut)
     colArrays['emission_kgPerH'] = np.concatenate(valsOut)
@@ -812,7 +820,13 @@ def createPDFCache(config):
         colVals = []
         for groupKey in groupKeysList:
             colVals.append(groupKey[colIdx])
-        colArrays[col] = np.repeat(np.array(colVals), groupSizes)
+        keyArr = np.asarray(colVals)
+        if keyArr.dtype.kind in ('U', 'S'):
+            # Object-dtype repeat copies REFERENCES to the per-group strings (the old
+            # [value] * n lists' memory behaviour); a '<U' array materialises a separate
+            # string per row — measured ~+26% tree peak RSS. See _buildCoarseCacheLevel.
+            keyArr = np.array(colVals, dtype=object)
+        colArrays[col] = np.repeat(keyArr, groupSizes)
     colArrays['startTime_s'] = np.concatenate(startsOut)
     colArrays['endTime_s'] = np.concatenate(endsOut)
     colArrays['emission_kgPerH'] = np.concatenate(valsOut)

--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -980,7 +980,9 @@ def _makePDFRows(mcRunTSList, identityCols, CICategory, totalSimSecs):
         'cumulativeProbability': cdf.data['cumulative_probability'].values,
     })
 
-def _buildPDFForGroupFromCache(groupDF, identityCols, CICategory, totalSimSecs, binSize=1e-6):
+def _buildPDFForGroupFromCacheLegacy(groupDF, identityCols, CICategory, totalSimSecs, binSize=1e-6):
+    # LEGACY implementation, retained verbatim (issue #121 round 2): reference for the
+    # equivalence tests of the array-native path below, exactly as _sumLegacy is for sum().
     fullMCRunTSList = []
     noFugMCRunTSList = []
     # Tier 1c: check once whether this group has any FUGITIVE intervals
@@ -1019,7 +1021,9 @@ def _buildPDFForGroupFromCache(groupDF, identityCols, CICategory, totalSimSecs, 
     }
     return _makePDFRows(fullMCRunTSList, identityCols, CICategory, totalSimSecs), _makePDFRows(noFugMCRunTSList, identityCols, CICategory, totalSimSecs), stats
 
-def calculatePDFSummaryFromCache(cacheDF, totalSimSecs, binSize=1e-6, groupings=None):
+def _calculatePDFSummaryFromCacheLegacy(cacheDF, totalSimSecs, binSize=1e-6, groupings=None):
+    # LEGACY implementation, retained verbatim (issue #121 round 2): reference for the
+    # equivalence tests of the array-native calculatePDFSummaryFromCache below.
     if groupings is None:
         groupings = PDF_GROUPINGS
     fullResultDFList = []
@@ -1029,7 +1033,7 @@ def calculatePDFSummaryFromCache(cacheDF, totalSimSecs, binSize=1e-6, groupings=
         levelDF = cacheDF[cacheDF['cacheLevel'] == CICategory]
         for _, groupDF in levelDF.groupby(groupCols):
             identityCols = {col: groupDF[col].iloc[0] for col in groupCols}
-            fullPDFRows, noFugPDFRows, stats = _buildPDFForGroupFromCache(groupDF, identityCols, CICategory, totalSimSecs, binSize)
+            fullPDFRows, noFugPDFRows, stats = _buildPDFForGroupFromCacheLegacy(groupDF, identityCols, CICategory, totalSimSecs, binSize)
             statsList.append(stats)
             if fullPDFRows is not None:
                 fullResultDFList.append(fullPDFRows)
@@ -1039,6 +1043,207 @@ def calculatePDFSummaryFromCache(cacheDF, totalSimSecs, binSize=1e-6, groupings=
     noFugPDFDF = pd.concat(noFugResultDFList) if noFugResultDFList else pd.DataFrame()
     statsDF = pd.DataFrame(statsList) if statsList else pd.DataFrame()
     return fullPDFDF, noFugPDFDF, statsDF
+
+def _validateCacheBoundary(cacheDF):
+    """One-pass boundary validation of a PDF cache frame (issue #121, round 2).
+
+    The legacy PDF build validated cache rows implicitly: every sub-group went through the
+    TimeseriesRLE constructor (_cacheGroupToTimeseriesRLE), whose per-row checks (positive
+    durations; no overlap between consecutive rows as stored) ran once PER SUB-GROUP — ~100k
+    frame constructions per site. The array-native build skips those constructions, so the
+    defence moves HERE: one vectorized pass over the whole frame, run once per
+    calculatePDFSummaryFromCache call. This matters because cacheDF is not always this
+    process's own output — validatePDFCache and PDF-recalculation flows load it from parquet.
+
+    The overlap check partitions by the finest cache identity (cacheLevel x identity columns x
+    mcRun x facilityID): within each original sub-frame those columns are constant (coarse
+    levels fill absent identity columns with '' and carry NaN facilityID — dropna=False keeps
+    those rows grouped), so this partition reproduces exactly the row runs the per-sub-group
+    constructors used to see. Raises the same exception type they raised.
+    """
+    badDuration = cacheDF['endTime_s'] <= cacheDF['startTime_s']
+    if badDuration.any():
+        msg = f"PDF cache has {int(badDuration.sum())} zero/negative-duration interval row(s)"
+        logger.error(msg)
+        raise ts.MalformedTimeseriesError(msg)
+    keyCols = ['cacheLevel', *CACHE_IDENTITY_COLS, 'mcRun']
+    if 'facilityID' in cacheDF.columns:
+        keyCols = [*keyCols, 'facilityID']
+    nextStart = cacheDF.groupby(keyCols, dropna=False, sort=False)['startTime_s'].shift(-1)
+    overlap = cacheDF['endTime_s'] > nextStart   # NaN (last row of a partition) compares False
+    if overlap.any():
+        msg = f"PDF cache has {int(overlap.sum())} overlapping interval row(s) within a cache partition"
+        logger.error(msg)
+        raise ts.MalformedTimeseriesError(msg)
+
+
+def _catArraysFromCacheRows(catDF):
+    """Extract one emission-category's cache rows as (starts, ends, values) arrays.
+
+    Mirrors the legacy branch pair in _buildPDFForGroupFromCacheLegacy: when the rows carry
+    facility detail (fine cache level), the per-facility interval sets are SUMMED into one
+    timeseries — including for a single facility, because the legacy code always routed the
+    facility branch through TimeseriesSet.sum() (whose residual clip and boundary merging are
+    part of the observable output). Coarse-level rows (facilityID NaN) are taken as-is, exactly
+    as the legacy code wrapped them in a single un-summed RLE."""
+    if 'facilityID' in catDF.columns and catDF['facilityID'].notna().any():
+        startsList = []
+        endsList = []
+        valsList = []
+        for _, facilityDF in catDF.groupby('facilityID'):
+            startsList.append(facilityDF['startTime_s'].to_numpy())
+            endsList.append(facilityDF['endTime_s'].to_numpy())
+            valsList.append(facilityDF['emission_kgPerH'].to_numpy())
+        ret = ts.sumEventArrays(startsList, endsList, valsList)
+        return ret
+    ret = (catDF['startTime_s'].to_numpy(), catDF['endTime_s'].to_numpy(),
+           catDF['emission_kgPerH'].to_numpy())
+    return ret
+
+
+def _buildPDFArraysForGroup(groupDF, binSize):
+    """Array-native replacement for the per-group body of the legacy PDF build (issue #121 r2).
+
+    Returns (fullDist, noFugDist, mcRunCount, buildSeconds), where each dist is either None (no
+    contributing intervals) or a (values, durations) pair of parallel lists of arrays — one list
+    entry per MC run — ready for ts.durationWeightedDistribution. The per-run logic replicates
+    the legacy path exactly, including the #70 Tier-1 shortcuts:
+      - Tier 1a: a single emission category skips the cross-category summation entirely;
+      - Tier 1b: a group with no FUGITIVE intervals reuses the full result for noFugitive
+        (same rounded arrays, no recompute);
+      - Tier 1c: the FUGITIVE presence check runs once per group, not per run.
+    Rounding (_roundForPDF) is applied AFTER cross-category summation, per run, exactly where
+    the legacy code applied it via df.assign."""
+    hasFugitive = 'FUGITIVE' in groupDF['modelEmissionCategory'].values
+    fullValsList = []
+    fullDursList = []
+    noFugValsList = []
+    noFugDursList = []
+    mcRunCount = 0
+    with Timer("build MC run timeseries from coarse cache", loglevel=logging.DEBUG) as t:
+        for _, mcRunDF in groupDF.groupby('mcRun'):
+            catArrays = {}
+            for emCat, catDF in mcRunDF.groupby('modelEmissionCategory'):
+                catArrays[emCat] = _catArraysFromCacheRows(catDF)
+            catList = list(catArrays.values())
+            # Tier 1a: single category — its arrays ARE the full timeseries, no summation.
+            if len(catList) == 1:
+                fullStarts, fullEnds, fullVals = catList[0]
+            else:
+                sList = []
+                eList = []
+                vList = []
+                for starts, ends, vals in catList:
+                    sList.append(starts)
+                    eList.append(ends)
+                    vList.append(vals)
+                fullStarts, fullEnds, fullVals = ts.sumEventArrays(sList, eList, vList)
+            if len(fullVals) > 0:
+                fullValsRounded = _roundForPDF(fullVals, binSize)
+                fullValsList.append(fullValsRounded)
+                fullDursList.append(fullEnds - fullStarts)
+                mcRunCount += 1
+                # Tier 1b: no FUGITIVE anywhere in the group — noFugitive == full; share the
+                # already-rounded arrays instead of recomputing (legacy appended the same
+                # rounded TS object).
+                if not hasFugitive:
+                    noFugValsList.append(fullValsRounded)
+                    noFugDursList.append(fullEnds - fullStarts)
+            if hasFugitive:
+                noFugCatList = []
+                for emCat, arrays in catArrays.items():
+                    if emCat != 'FUGITIVE':
+                        noFugCatList.append(arrays)
+                if len(noFugCatList) == 1:
+                    nfStarts, nfEnds, nfVals = noFugCatList[0]
+                elif noFugCatList:
+                    sList = []
+                    eList = []
+                    vList = []
+                    for starts, ends, vals in noFugCatList:
+                        sList.append(starts)
+                        eList.append(ends)
+                        vList.append(vals)
+                    nfStarts, nfEnds, nfVals = ts.sumEventArrays(sList, eList, vList)
+                else:
+                    nfVals = np.array([])
+                if len(nfVals) > 0:
+                    noFugValsList.append(_roundForPDF(nfVals, binSize))
+                    noFugDursList.append(nfEnds - nfStarts)
+        t.setCount(mcRunCount)
+    fullDist = (fullValsList, fullDursList) if fullValsList else None
+    noFugDist = (noFugValsList, noFugDursList) if noFugValsList else None
+    ret = (fullDist, noFugDist, mcRunCount, t.deltat.total_seconds())
+    return ret
+
+
+def calculatePDFSummaryFromCache(cacheDF, totalSimSecs, binSize=1e-6, groupings=None):
+    """Build the full + noFugitive PDF/CDF frames from a PDF cache; array-native (issue #121 r2).
+
+    Produces the same rows, in the same order, with the same columns as the legacy
+    implementation (retained above as _calculatePDFSummaryFromCacheLegacy): for every
+    (cacheLevel, identity) group, the duration-weighted distribution of the summed, rounded
+    emission rates — 'probability' normalised by totalSimSecs (so it sums to the ACTIVE
+    fraction of simulated time, not 1.0), 'cumulativeProbability' normalised within the
+    distribution. Three mechanical changes, no behavioural ones:
+      1. cache-row validation runs ONCE, vectorized (_validateCacheBoundary), instead of once
+         per sub-group inside TimeseriesRLE constructors;
+      2. per-group summation and the per-distribution groupby run on raw arrays
+         (ts.sumEventArrays / ts.durationWeightedDistribution);
+      3. output rows accumulate as arrays and materialise as ONE frame per grouping level
+         (identity columns via object-dtype np.repeat — see the RAM note in
+         _buildCoarseCacheLevel), instead of one frame per distribution + a global concat.
+    """
+    if groupings is None:
+        groupings = PDF_GROUPINGS
+    _validateCacheBoundary(cacheDF)
+    fullLevelDFs = []
+    noFugLevelDFs = []
+    statsList = []
+    for CICategory, groupCols in groupings:
+        levelDF = cacheDF[cacheDF['cacheLevel'] == CICategory]
+        fullAcc = {'keys': [], 'sizes': [], 'vals': [], 'probs': [], 'cums': []}
+        noFugAcc = {'keys': [], 'sizes': [], 'vals': [], 'probs': [], 'cums': []}
+        for groupKey, groupDF in levelDF.groupby(groupCols):
+            keyTuple = groupKey if isinstance(groupKey, tuple) else (groupKey,)
+            fullDist, noFugDist, mcRunCount, buildSeconds = _buildPDFArraysForGroup(groupDF, binSize)
+            stats = {'CICategory': CICategory, **dict(zip(groupCols, keyTuple)),
+                     'mcRunCount': mcRunCount, 'buildSeconds': buildSeconds}
+            statsList.append(stats)
+            for dist, acc in ((fullDist, fullAcc), (noFugDist, noFugAcc)):
+                if dist is None:
+                    continue
+                values, durations = ts.durationWeightedDistribution(dist[0], dist[1])
+                if len(values) == 0:
+                    continue
+                acc['keys'].append(keyTuple)
+                acc['sizes'].append(len(values))
+                acc['vals'].append(values)
+                acc['probs'].append(durations / totalSimSecs)
+                acc['cums'].append(np.cumsum(durations) / durations.sum())
+        for acc, levelDFs in ((fullAcc, fullLevelDFs), (noFugAcc, noFugLevelDFs)):
+            if not acc['keys']:
+                continue
+            sizes = np.array(acc['sizes'])
+            colArrays = {}
+            for colIdx, col in enumerate(groupCols):
+                colVals = []
+                for keyTuple in acc['keys']:
+                    colVals.append(keyTuple[colIdx])
+                keyArr = np.asarray(colVals)
+                if keyArr.dtype.kind in ('U', 'S'):
+                    keyArr = np.array(colVals, dtype=object)
+                colArrays[col] = np.repeat(keyArr, sizes)
+            colArrays['CICategory'] = np.full(int(sizes.sum()), CICategory, dtype=object)
+            colArrays['emissionRate_kgPerH'] = np.concatenate(acc['vals'])
+            colArrays['probability'] = np.concatenate(acc['probs'])
+            colArrays['cumulativeProbability'] = np.concatenate(acc['cums'])
+            levelDFs.append(pd.DataFrame(colArrays))
+    fullPDFDF = pd.concat(fullLevelDFs) if fullLevelDFs else pd.DataFrame()
+    noFugPDFDF = pd.concat(noFugLevelDFs) if noFugLevelDFs else pd.DataFrame()
+    statsDF = pd.DataFrame(statsList) if statsList else pd.DataFrame()
+    return fullPDFDF, noFugPDFDF, statsDF
+
 
 def validatePDFCache(config):
     logger.info(f"Validating PDF cache for site {config['siteName']}")

--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -660,7 +660,40 @@ def _roundForPDF(values, binSize=1e-6):
     return np.round(np.asarray(values) / binSize) * binSize
 
 
-def _buildCoarseCacheLevel(fineDF, groupCols, levelName, binSize=1e-6):
+def _coalesceAdjacentEqual(starts, ends, values):
+    """Merge consecutive intervals that share a value into single spanning intervals.
+
+    Intervals are assumed time-ordered and contiguous (a summed step function). Each maximal run
+    of equal consecutive values collapses to one interval [firstStart, lastEnd]; the total duration
+    at each value is preserved exactly, so a duration-weighted PDF built from the coalesced
+    intervals is identical to one built from the un-coalesced intervals."""
+    values = np.asarray(values)
+    starts = np.asarray(starts)
+    ends = np.asarray(ends)
+    if len(values) == 0:
+        return starts, ends, values
+    isRunStart = np.ones(len(values), dtype=bool)
+    isRunStart[1:] = values[1:] != values[:-1]
+    runStartIdx = np.flatnonzero(isRunStart)
+    runEndIdx = np.append(runStartIdx[1:] - 1, len(values) - 1)
+    return starts[runStartIdx], ends[runEndIdx], values[runStartIdx]
+
+
+def _roundedCacheArrays(summedTS, binSize, coalesce):
+    """Round a summed timeseries' rates to binSize; return (startTimes, endTimes, values).
+
+    When coalesce is True, consecutive intervals sharing a rounded rate are merged
+    (_coalesceAdjacentEqual) — the change that lets a coarser binSize actually shrink the cache
+    without altering the PDF. When False, every interval is kept (legacy behaviour)."""
+    starts = summedTS.df[summedTS.startTimeColName].values
+    ends = summedTS.df[summedTS.endTimeColName].values
+    values = _roundForPDF(summedTS.df[summedTS.valueColName].values, binSize)
+    if coalesce:
+        starts, ends, values = _coalesceAdjacentEqual(starts, ends, values)
+    return starts, ends, values
+
+
+def _buildCoarseCacheLevel(fineDF, groupCols, levelName, binSize=1e-6, coalesce=False):
     aggGroupCols = [*groupCols, 'modelEmissionCategory', 'mcRun']
     rowsList = []
     for groupKey, groupDF in fineDF.groupby(aggGroupCols):
@@ -671,12 +704,13 @@ def _buildCoarseCacheLevel(fineDF, groupCols, levelName, binSize=1e-6):
         if summedTS.isempty():
             continue
         identityDict = dict(zip(aggGroupCols, groupKey))
-        n = len(summedTS.df)
+        startArr, endArr, valArr = _roundedCacheArrays(summedTS, binSize, coalesce)
+        n = len(valArr)
         rowsList.append(pd.DataFrame({
             **{col: [val] * n for col, val in identityDict.items()},
-            'startTime_s': summedTS.df[summedTS.startTimeColName].values,
-            'endTime_s': summedTS.df[summedTS.endTimeColName].values,
-            'emission_kgPerH': _roundForPDF(summedTS.df[summedTS.valueColName].values, binSize),
+            'startTime_s': startArr,
+            'endTime_s': endArr,
+            'emission_kgPerH': valArr,
             'cacheLevel': [levelName] * n,
         }))
     return pd.concat(rowsList, ignore_index=True) if rowsList else pd.DataFrame()
@@ -691,7 +725,17 @@ def createPDFCache(config):
         t0.setCount(len(instEmissionDF))
 
     instEmissionDF = _removeZeroEmissionEvents(instEmissionDF)
+    # pdfSpecies (optional config list): restrict the PDF cascade to these species values only.
+    # The 'species' column carries 16 values incl. non-species energy rows (LHV, DeltaH); each
+    # value multiplies groups/rows/time ~linearly through every cache level. Default None keeps
+    # all values — identical outputs to the unfiltered engine (backward compatible). Annual /
+    # instantaneous summaries are unaffected (this filter exists only inside the PDF cascade).
+    pdfSpecies = config.get('pdfSpecies', None)
+    if pdfSpecies:
+        instEmissionDF = instEmissionDF[instEmissionDF['species'].isin(pdfSpecies)]
+        logger.info(f"PDF cascade restricted to species {pdfSpecies}: {len(instEmissionDF)} rows")
     binSize = config.get('pdfBinSize', 1e-6)
+    coalesce = config.get('pdfCoalesce', False)
     groupCols = ['facilityID', *CACHE_IDENTITY_COLS, 'mcRun']
     cacheRowsList = []
     with Timer("Build PDF cache") as t1:
@@ -699,13 +743,14 @@ def createPDFCache(config):
             summedTS = _buildMCRunTimeseries(groupDF)
             if summedTS.isempty():
                 continue
-            n = len(summedTS.df)
+            startArr, endArr, valArr = _roundedCacheArrays(summedTS, binSize, coalesce)
+            n = len(valArr)
             identityDict = dict(zip(groupCols, groupKey))
             cacheRowsList.append(pd.DataFrame({
                 **{col: [val] * n for col, val in identityDict.items()},
-                'startTime_s': summedTS.df[summedTS.startTimeColName].values,
-                'endTime_s': summedTS.df[summedTS.endTimeColName].values,
-                'emission_kgPerH': _roundForPDF(summedTS.df[summedTS.valueColName].values, binSize),
+                'startTime_s': startArr,
+                'endTime_s': endArr,
+                'emission_kgPerH': valArr,
             }))
         t1.setCount(len(cacheRowsList))
 
@@ -721,7 +766,7 @@ def createPDFCache(config):
 
     for levelName, levelGroupCols in PDF_GROUPINGS[:-1]:
         with Timer(f"Build coarse cache {levelName}", loglevel=logging.DEBUG) as t2:
-            coarseDF = _buildCoarseCacheLevel(fineCacheDF, levelGroupCols, levelName, binSize)
+            coarseDF = _buildCoarseCacheLevel(fineCacheDF, levelGroupCols, levelName, binSize, coalesce)
             t2.setCount(len(coarseDF))
         if not coarseDF.empty:
             for col in [*CACHE_IDENTITY_COLS, 'mcRun']:

--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -661,19 +661,31 @@ def _roundForPDF(values, binSize=1e-6):
 
 
 def _coalesceAdjacentEqual(starts, ends, values):
-    """Merge consecutive intervals that share a value into single spanning intervals.
+    """Merge consecutive intervals that share a value AND are contiguous into spanning intervals.
 
-    Intervals are assumed time-ordered and contiguous (a summed step function). Each maximal run
-    of equal consecutive values collapses to one interval [firstStart, lastEnd]; the total duration
-    at each value is preserved exactly, so a duration-weighted PDF built from the coalesced
-    intervals is identical to one built from the un-coalesced intervals."""
+    Each maximal run of equal-valued, gap-free consecutive intervals collapses to one interval
+    [firstStart, lastEnd]. Because only contiguous intervals merge, the step function is
+    unchanged at every instant, so the total duration at each value — and therefore the
+    duration-weighted PDF/CDF — is preserved EXACTLY.
+
+    The contiguity condition (starts[i] == ends[i-1]) is load-bearing, not pedantry: summed
+    timeseries contain GAPS wherever the summation's near-zero residual clip removed an interval
+    (and wherever nothing emitted), and equal-valued intervals frequently flank such gaps. An
+    earlier version of this function merged on value equality alone and silently bridged those
+    gaps — stamping non-emitting time with an emission rate. Measured on the real mc=100
+    workload: of 1,011,270 equal-value consecutive pairs, 1,010,977 were contiguous (legitimate
+    merges) and just 293 bridged gaps — but those 293 spanned 4.5e9 seconds and shifted some
+    distributions by KS 0.11+. The contiguity check keeps ~99.97% of the row reduction and
+    restores exactness (verified by the KS sweep's coalesce-on-vs-off self-check)."""
     values = np.asarray(values)
     starts = np.asarray(starts)
     ends = np.asarray(ends)
     if len(values) == 0:
         return starts, ends, values
     isRunStart = np.ones(len(values), dtype=bool)
-    isRunStart[1:] = values[1:] != values[:-1]
+    # A new run starts where the value CHANGES or where the interval is NOT contiguous with its
+    # predecessor (a gap — merging across it would alter the step function).
+    isRunStart[1:] = (values[1:] != values[:-1]) | (starts[1:] != ends[:-1])
     runStartIdx = np.flatnonzero(isRunStart)
     runEndIdx = np.append(runStartIdx[1:] - 1, len(values) - 1)
     return starts[runStartIdx], ends[runEndIdx], values[runStartIdx]

--- a/src/Summaries2.py
+++ b/src/Summaries2.py
@@ -679,41 +679,75 @@ def _coalesceAdjacentEqual(starts, ends, values):
     return starts[runStartIdx], ends[runEndIdx], values[runStartIdx]
 
 
-def _roundedCacheArrays(summedTS, binSize, coalesce):
-    """Round a summed timeseries' rates to binSize; return (startTimes, endTimes, values).
+def _roundedCacheArrays(startTimes, endTimes, values, binSize, coalesce):
+    """Round summed emission rates to binSize; return (startTimes, endTimes, values) arrays.
 
-    When coalesce is True, consecutive intervals sharing a rounded rate are merged
-    (_coalesceAdjacentEqual) — the change that lets a coarser binSize actually shrink the cache
-    without altering the PDF. When False, every interval is kept (legacy behaviour)."""
-    starts = summedTS.df[summedTS.startTimeColName].values
-    ends = summedTS.df[summedTS.endTimeColName].values
-    values = _roundForPDF(summedTS.df[summedTS.valueColName].values, binSize)
+    Operates directly on the arrays produced by ts.sumEventArrays (issue #121) — no timeseries
+    object needed. When coalesce is True, consecutive intervals sharing a rounded rate are
+    merged (_coalesceAdjacentEqual) — the change that lets a coarser binSize actually shrink
+    the cache without altering the duration-weighted PDF. When False, every interval is kept
+    (legacy behaviour)."""
+    values = _roundForPDF(values, binSize)
     if coalesce:
-        starts, ends, values = _coalesceAdjacentEqual(starts, ends, values)
-    return starts, ends, values
+        startTimes, endTimes, values = _coalesceAdjacentEqual(startTimes, endTimes, values)
+    return startTimes, endTimes, values
 
 
 def _buildCoarseCacheLevel(fineDF, groupCols, levelName, binSize=1e-6, coalesce=False):
+    """Aggregate the fine cache to one coarse cache level; array-native path (issue #121).
+
+    Two changes from the frame-per-group original, both pure mechanics (same math, same rows):
+      1. Each sub-group's intervals go straight from the fine-cache columns into
+         ts.sumEventArrays — no per-sub-group TimeseriesRLE construction. The fine cache rows
+         being aggregated here are outputs of THIS call's own summation kernel, so their RLE
+         invariants already hold; re-validating them per sub-group was pure overhead.
+      2. Store-side accumulation: per-group results are collected as arrays and materialised
+         as ONE DataFrame per level (np.repeat for the identity columns), instead of one
+         DataFrame per group plus a concat over all of them. Profiling (issue #121) showed the
+         per-group frame construction + N-way concat rivaled the summation itself.
+    """
     aggGroupCols = [*groupCols, 'modelEmissionCategory', 'mcRun']
-    rowsList = []
+    groupKeysList = []
+    groupSizesList = []
+    startsOut = []
+    endsOut = []
+    valsOut = []
     for groupKey, groupDF in fineDF.groupby(aggGroupCols):
-        catTSList = []
+        startsList = []
+        endsList = []
+        valsList = []
         for _, subDF in groupDF.groupby(['facilityID', *CACHE_IDENTITY_COLS]):
-            catTSList.append(_cacheGroupToTimeseriesRLE(subDF))
-        summedTS = ts.TimeseriesSet(catTSList).sum()
-        if summedTS.isempty():
+            startsList.append(subDF['startTime_s'].to_numpy())
+            endsList.append(subDF['endTime_s'].to_numpy())
+            valsList.append(subDF['emission_kgPerH'].to_numpy())
+        startArr, endArr, valArr = ts.sumEventArrays(startsList, endsList, valsList)
+        startArr, endArr, valArr = _roundedCacheArrays(startArr, endArr, valArr, binSize, coalesce)
+        if len(valArr) == 0:
             continue
-        identityDict = dict(zip(aggGroupCols, groupKey))
-        startArr, endArr, valArr = _roundedCacheArrays(summedTS, binSize, coalesce)
-        n = len(valArr)
-        rowsList.append(pd.DataFrame({
-            **{col: [val] * n for col, val in identityDict.items()},
-            'startTime_s': startArr,
-            'endTime_s': endArr,
-            'emission_kgPerH': valArr,
-            'cacheLevel': [levelName] * n,
-        }))
-    return pd.concat(rowsList, ignore_index=True) if rowsList else pd.DataFrame()
+        groupKeysList.append(groupKey)
+        groupSizesList.append(len(valArr))
+        startsOut.append(startArr)
+        endsOut.append(endArr)
+        valsOut.append(valArr)
+    if not groupKeysList:
+        return pd.DataFrame()
+    # One frame for the whole level. Identity columns are built by repeating each group's key
+    # value by that group's interval count; np.array infers the per-column dtype from the key
+    # values themselves (strings stay strings, mcRun stays integer), matching what the old
+    # per-group frames produced.
+    groupSizes = np.array(groupSizesList)
+    colArrays = {}
+    for colIdx, col in enumerate(aggGroupCols):
+        colVals = []
+        for groupKey in groupKeysList:
+            colVals.append(groupKey[colIdx])
+        colArrays[col] = np.repeat(np.array(colVals), groupSizes)
+    colArrays['startTime_s'] = np.concatenate(startsOut)
+    colArrays['endTime_s'] = np.concatenate(endsOut)
+    colArrays['emission_kgPerH'] = np.concatenate(valsOut)
+    totalRows = int(groupSizes.sum())
+    colArrays['cacheLevel'] = np.full(totalRows, levelName, dtype=object)
+    return pd.DataFrame(colArrays)
 
 def createPDFCache(config):
     logger.info(f"Creating PDF cache for site {config['siteName']}")
@@ -737,31 +771,55 @@ def createPDFCache(config):
     binSize = config.get('pdfBinSize', 1e-6)
     coalesce = config.get('pdfCoalesce', False)
     groupCols = ['facilityID', *CACHE_IDENTITY_COLS, 'mcRun']
-    cacheRowsList = []
+    # Array accumulation for the fine level (issue #121): collect each group's summed interval
+    # arrays plus its identity key, and materialise ONE DataFrame at the end (np.repeat for the
+    # identity columns) — replacing one DataFrame construction per group plus a group-count-wide
+    # concat, which profiling showed rivaled the summation work itself at ~100k groups/site.
+    groupKeysList = []
+    groupSizesList = []
+    startsOut = []
+    endsOut = []
+    valsOut = []
     with Timer("Build PDF cache") as t1:
         for groupKey, groupDF in instEmissionDF.groupby(groupCols):
             summedTS = _buildMCRunTimeseries(groupDF)
             if summedTS.isempty():
                 continue
-            startArr, endArr, valArr = _roundedCacheArrays(summedTS, binSize, coalesce)
-            n = len(valArr)
-            identityDict = dict(zip(groupCols, groupKey))
-            cacheRowsList.append(pd.DataFrame({
-                **{col: [val] * n for col, val in identityDict.items()},
-                'startTime_s': startArr,
-                'endTime_s': endArr,
-                'emission_kgPerH': valArr,
-            }))
-        t1.setCount(len(cacheRowsList))
+            startArr, endArr, valArr = _roundedCacheArrays(
+                summedTS.df[summedTS.startTimeColName].to_numpy(),
+                summedTS.df[summedTS.endTimeColName].to_numpy(),
+                summedTS.df[summedTS.valueColName].to_numpy(),
+                binSize, coalesce)
+            if len(valArr) == 0:
+                continue
+            groupKeysList.append(groupKey)
+            groupSizesList.append(len(valArr))
+            startsOut.append(startArr)
+            endsOut.append(endArr)
+            valsOut.append(valArr)
+        t1.setCount(len(groupKeysList))
 
-    if not cacheRowsList:
+    if not groupKeysList:
         logger.info(f"No cache rows for site {config['siteName']}, skipping PDF cache")
         return pd.DataFrame()
 
-    fineCacheDF = pd.concat(cacheRowsList, ignore_index=True)
+    # Same one-frame materialisation as _buildCoarseCacheLevel; per-column dtype is inferred
+    # from the key values (strings stay strings, mcRun stays integer), matching the frames the
+    # per-group construction used to produce.
+    groupSizes = np.array(groupSizesList)
+    colArrays = {}
+    for colIdx, col in enumerate(groupCols):
+        colVals = []
+        for groupKey in groupKeysList:
+            colVals.append(groupKey[colIdx])
+        colArrays[col] = np.repeat(np.array(colVals), groupSizes)
+    colArrays['startTime_s'] = np.concatenate(startsOut)
+    colArrays['endTime_s'] = np.concatenate(endsOut)
+    colArrays['emission_kgPerH'] = np.concatenate(valsOut)
+    fineCacheDF = pd.DataFrame(colArrays)
     fineCacheDF = fineCacheDF.assign(cacheLevel='modelReadableName')
     allLevelDFs = [fineCacheDF]
-    statsRows = [{'cacheLevel': 'modelReadableName', 'groupCount': len(cacheRowsList),
+    statsRows = [{'cacheLevel': 'modelReadableName', 'groupCount': len(groupKeysList),
                   'intervalRows': len(fineCacheDF), 'buildSeconds': t1.deltat.total_seconds()}]
 
     for levelName, levelGroupCols in PDF_GROUPINGS[:-1]:
@@ -802,15 +860,45 @@ def _buildMCRunTimeseries(mcRunDF):
         mcRun = mcRunDF['mcRun'].iloc[0]
         logger.warning(f"_buildMCRunTimeseries: {len(zeroDurationDF)} zero-duration events filtered out for site {site}, mcRun {mcRun}")
         mcRunDF = mcRunDF[mcRunDF['duration_s'] > 0]
-    emitterTSList = []
-    for _, emitterDF in mcRunDF.groupby('emitterID'):
-        starts = emitterDF['timestamp_s'].values
-        ends = starts + emitterDF['duration_s'].values
-        values = emitterDF['emission_kgPerS'].values * u.SECONDS_PER_HOUR
-        emitterTSList.append(ts.TimeseriesRLE.fromCollections(starts, ends, values))
+    # Array-native path (issue #121): collect each emitter's interval arrays and hand them
+    # straight to the summation kernel, instead of wrapping every emitter in a TimeseriesRLE
+    # (a DataFrame construction + per-row validation apiece) only for sum() to immediately
+    # extract the arrays back out. Raw InstEmissions IS a system boundary, so the validation
+    # TimeseriesRLE.__init__ used to provide is preserved below, vectorized, with the same
+    # exception type: an overlap between consecutive rows (as ordered) is malformed input.
+    startsList = []
+    endsList = []
+    valsList = []
+    emitterCount = 0
+    for emitterID, emitterDF in mcRunDF.groupby('emitterID'):
+        starts = emitterDF['timestamp_s'].to_numpy(dtype=float)
+        ends = starts + emitterDF['duration_s'].to_numpy(dtype=float)
+        values = emitterDF['emission_kgPerS'].to_numpy(dtype=float) * u.SECONDS_PER_HOUR
+        # Same check TimeseriesRLE.__init__ ran on each per-emitter frame: end[i] may not
+        # exceed the NEXT row's start (rows in their given order). Zero-duration rows were
+        # already filtered above (duration_s <= 0), mirroring the ctor's zero-duration guard.
+        if len(starts) > 1 and np.any(ends[:-1] > starts[1:]):
+            msg = f"Overlapping interval(s) for emitter {emitterID} in _buildMCRunTimeseries"
+            logger.error(msg)
+            raise ts.MalformedTimeseriesError(msg)
+        startsList.append(starts)
+        endsList.append(ends)
+        valsList.append(values)
+        emitterCount += 1
     with Timer("emitter sum", loglevel=logging.DEBUG) as t:
-        result = ts.TimeseriesSet(emitterTSList).sum()
-        t.setCount(len(emitterTSList))
+        sumStarts, sumEnds, sumValues = ts.sumEventArrays(startsList, endsList, valsList)
+        t.setCount(emitterCount)
+    if len(sumValues) == 0:
+        # Mirrors the legacy empty-sum result (default column names).
+        result = ts.TimeseriesRLE(pd.DataFrame(columns=['timestamp', 'nextTS', 'tsValue']))
+        return result
+    # Column names match what the legacy path produced (fromCollections' defaults propagated
+    # through sum() via the first member), so downstream consumers see an identical object.
+    # The kernel's output invariants let the trusted constructor skip re-validation.
+    result = ts.TimeseriesRLE.fromValidatedArrays(sumStarts, sumEnds, sumValues,
+                                                  startTimeColName='timestamp',
+                                                  endTimeColName='nextTS',
+                                                  valueColName='valueCollection')
     return result
 
 def _buildPDFForGroup(groupDF, identityCols, CICategory, totalSimSecs):

--- a/src/Timeseries.py
+++ b/src/Timeseries.py
@@ -297,6 +297,46 @@ class TimeseriesRLE(Timeseries):
         df = pd.DataFrame.from_records(dictList)
         return cls(df, valueColName=valueColName, **kwargs)
 
+    @classmethod
+    def fromValidatedArrays(cls, startTimes, endTimes, values,
+                            startTimeColName='timestamp', endTimeColName='nextTS',
+                            valueColName='tsValue', name=None, units=None):
+        """Trusted constructor for arrays whose RLE invariants hold BY CONSTRUCTION (issue #121).
+
+        __init__ validates every incoming frame: column presence, interval overlap
+        (endTime vs the next row's startTime), zero-duration rows, and end-time sortedness —
+        several pandas operations per construction. That is the right defence where data
+        ENTERS the system (raw event logs, files), but pure waste for the OUTPUT of
+        sumEventArrays, which guarantees strictly-increasing unique start times, contiguous
+        positive-duration intervals, and no overlaps by the way it is built (sorted unique
+        event times define the interval edges). Profiling (issue #121) showed this re-
+        validation, repeated ~50k times per site cache build, was a significant slice of
+        createPDFCache runtime.
+
+        This constructor therefore bypasses __init__ (object.__new__ + direct attribute
+        assignment) and sets every attribute __init__ would have set:
+          name/units (base Timeseries state), df, the three column-name fields, colList,
+          and sorted=True (asserted, not re-derived — the caller's construction guarantees it).
+        Callers MUST only pass arrays produced by sumEventArrays (or arrays with the same
+        proven invariants); anything else must go through the validating __init__.
+        """
+        obj = cls.__new__(cls)
+        # Base-class state (Timeseries.__init__ sets exactly these two).
+        obj.name = name
+        obj.units = units
+        # One DataFrame construction from columnar arrays — the single pandas object this
+        # path creates. reset_index is unnecessary: a fresh frame already has a RangeIndex.
+        obj.df = pd.DataFrame({startTimeColName: startTimes,
+                               endTimeColName: endTimes,
+                               valueColName: values})
+        obj.startTimeColName = startTimeColName
+        obj.endTimeColName = endTimeColName
+        obj.valueColName = valueColName
+        obj.colList = [startTimeColName, endTimeColName, valueColName]
+        # __init__ derives this via _isSorted(); the kernel's output is sorted by construction.
+        obj.sorted = True
+        return obj
+
     @property
     def _durations(self):
         dur = self.df[self.endTimeColName] - self.df[self.startTimeColName]
@@ -1129,6 +1169,68 @@ class TimeseriesCDF():
 # TimeseriesSet
 #
 
+def sumEventArrays(startsList, endsList, valsList):
+    """Array-native signed-event sweep summation (issue #121).
+
+    This is EXACTLY the algorithm TimeseriesSet.sum() has always used — emit +value at each
+    interval start and -value at each interval end, sort all events by time, running-sum the
+    deltas to get the summed level on each inter-event interval, and clip near-zero floating-
+    point residuals — implemented on raw numpy arrays instead of per-call DataFrames, concat,
+    and groupby. Profiling (issue #121) showed ~99% of createPDFCache runtime was pandas
+    object machinery around this algorithm; the arithmetic itself is unchanged.
+
+    Parameters are parallel lists (one entry per input timeseries) of 1-D arrays:
+    startsList[i] / endsList[i] / valsList[i] hold interval start times, end times, and values
+    of input i. Intervals within one input must be non-overlapping (callers validate, exactly
+    as TimeseriesRLE.__init__ always has); input ORDER does not matter because all events are
+    globally sorted here.
+
+    Returns (startTimes, endTimes, values) arrays of the summed step function. Output
+    invariants, BY CONSTRUCTION (these are what let fromValidatedArrays skip re-validation):
+      - startTimes is strictly increasing (unique sorted event times);
+      - endTimes[i] is the next unique event time, so every duration is > 0;
+      - intervals are contiguous and non-overlapping.
+    """
+    # Signed event table: one +value event per interval start, one -value event per interval
+    # end. np.negative allocates the negated copies (the legacy path's 'delta': -vals).
+    times = np.concatenate(startsList + endsList)
+    deltas = np.concatenate(valsList + list(map(np.negative, valsList)))
+    if len(times) == 0:
+        empty = np.array([])
+        return empty, empty, empty
+    # Global sort by event time. 'stable' keeps a deterministic order for events sharing a
+    # timestamp; the segment-sum below adds all same-time deltas together regardless, exactly
+    # like the legacy groupby('time').sum(). (Float addition ORDER within a shared timestamp
+    # can differ from pandas' internal order, so results may differ at the ~1e-16 ULP level —
+    # far below both the 1e-10 residual clip here and the >=1e-6 _roundForPDF quantisation
+    # applied immediately downstream in the PDF cascade.)
+    order = np.argsort(times, kind="stable")
+    times = times[order]
+    deltas = deltas[order]
+    # Segment boundaries: positions where the (sorted) event time changes. reduceat then sums
+    # each same-time run of deltas — the vectorized equivalent of groupby('time')['delta'].sum().
+    isNew = np.empty(len(times), dtype=bool)
+    isNew[0] = True
+    isNew[1:] = times[1:] != times[:-1]
+    segStartIdx = np.flatnonzero(isNew)
+    uniqueTimes = times[segStartIdx]
+    segSums = np.add.reduceat(deltas, segStartIdx)
+    # Running level: cumsum of the per-time net deltas gives the summed value on the interval
+    # [uniqueTimes[i], uniqueTimes[i+1]). Identical to the legacy cumsum over the grouped table.
+    cumLevels = np.cumsum(segSums)
+    startTimes = uniqueTimes[:-1]
+    endTimes = uniqueTimes[1:]
+    values = cumLevels[:-1]
+    # Near-zero residual clip — SAME semantics and SAME 1e-10 threshold as the legacy sum():
+    # when several inputs share an endpoint, their +/- deltas cancel with float64 rounding
+    # noise (~1e-14 for kg/h-scale rates) instead of exact zeros, creating phantom intervals
+    # spanning the gaps between real events. NOTE this deliberately drops ALL near-zero
+    # intervals, positive ones included — preserving the legacy behaviour exactly (see the
+    # original comment retained in _sumLegacy).
+    keepMask = np.abs(values) >= 1e-10
+    return startTimes[keepMask], endTimes[keepMask], values[keepMask]
+
+
 class TimeseriesSet():
 
     def __init__(self, tsSetList):
@@ -1139,6 +1241,49 @@ class TimeseriesSet():
         self.tsSetList.append(ts)
 
     def sum(self):
+        """Sum the member timeseries into one summed step function (TimeseriesRLE).
+
+        Fast path (issue #121): when every member is a PLAIN TimeseriesRLE — an exact type()
+        check, so subclasses like TimeseriesCategorical (state timelines, whose values are
+        category codes that must not be arithmetically summed) always take the legacy path —
+        extract the raw arrays once, run the array-native kernel (sumEventArrays), and wrap
+        the result via the trusted constructor. Same algorithm, same residual-clip semantics,
+        none of the per-call DataFrame/concat/groupby overhead.
+
+        The legacy frame-based implementation is retained verbatim as _sumLegacy: it is the
+        fallback for mixed/subclassed member sets AND the reference implementation the unit
+        tests compare the fast path against.
+        """
+        if not self.tsSetList:
+            return TimeseriesRLE(pd.DataFrame(columns=['timestamp', 'nextTS', 'tsValue']))
+        allPlainRLE = all(map(lambda singleTS: type(singleTS) is TimeseriesRLE, self.tsSetList))
+        if not allPlainRLE:
+            return self._sumLegacy()
+
+        first = self.tsSetList[0]
+        startsList = []
+        endsList = []
+        valsList = []
+        for singleTS in self.tsSetList:
+            df = singleTS.df
+            # .to_numpy() on each column once per member — the only pandas touch on this path.
+            startsList.append(df[singleTS.startTimeColName].to_numpy())
+            endsList.append(df[singleTS.endTimeColName].to_numpy())
+            valsList.append(df[singleTS.valueColName].to_numpy())
+        startTimes, endTimes, values = sumEventArrays(startsList, endsList, valsList)
+        if len(values) == 0:
+            # Legacy behaviour: an empty result uses the DEFAULT column names, not the first
+            # member's (see the tail of _sumLegacy) — preserved exactly.
+            return TimeseriesRLE(pd.DataFrame(columns=['timestamp', 'nextTS', 'tsValue']))
+        # The kernel's output invariants (strictly increasing, positive-duration, non-
+        # overlapping intervals) hold by construction, so the trusted constructor may skip
+        # the per-row validation TimeseriesRLE.__init__ would re-run.
+        return TimeseriesRLE.fromValidatedArrays(startTimes, endTimes, values,
+                                                 startTimeColName=first.startTimeColName,
+                                                 endTimeColName=first.endTimeColName,
+                                                 valueColName=first.valueColName)
+
+    def _sumLegacy(self):
         if not self.tsSetList:
             return TimeseriesRLE(pd.DataFrame(columns=['timestamp', 'nextTS', 'tsValue']))
 

--- a/src/Timeseries.py
+++ b/src/Timeseries.py
@@ -1236,6 +1236,47 @@ def sumEventArrays(startsList, endsList, valsList):
     return startTimes[keepMask], endTimes[keepMask], values[keepMask]
 
 
+def durationWeightedDistribution(valuesList, durationsList):
+    """Array-native duration-weighted value distribution (issue #121, round 2).
+
+    The exact vectorized equivalent of what TimeseriesSet.toPDF() has always computed —
+    concatenate the member intervals and run `durations.groupby(values).sum()` — i.e. for every
+    distinct interval VALUE, the total DURATION spent at that value. That (value, totalDuration)
+    table is the duration-weighted PDF the whole cascade is built on; toCDF() is then just a
+    cumulative sum over it. Profiling showed the pandas groupby-per-distribution (one call per
+    PDF group, ~13k groups per site) was dominated by per-call machinery, exactly like the
+    summation kernel's case.
+
+    Parameters are parallel lists of 1-D arrays (one entry per contributing timeseries, e.g. one
+    per MC run): valuesList[i] holds interval values, durationsList[i] the matching durations.
+
+    Returns (uniqueValues, totalDurations): uniqueValues strictly ascending (pandas groupby with
+    sort=True ordered its keys the same way), totalDurations the per-value duration sums. Empty
+    inputs return empty arrays.
+    """
+    if not valuesList:
+        empty = np.array([])
+        return empty, empty
+    values = np.concatenate(valuesList)
+    durations = np.concatenate(durationsList)
+    if len(values) == 0:
+        empty = np.array([])
+        return empty, empty
+    # Sort values (stable, deterministic); equal values become contiguous runs.
+    order = np.argsort(values, kind="stable")
+    sortedVals = values[order]
+    sortedDurs = durations[order]
+    # Segment boundaries where the sorted value changes; reduceat sums each run's durations —
+    # the vectorized equivalent of groupby(value)['duration'].sum() with sorted keys.
+    isNew = np.empty(len(sortedVals), dtype=bool)
+    isNew[0] = True
+    isNew[1:] = sortedVals[1:] != sortedVals[:-1]
+    segStartIdx = np.flatnonzero(isNew)
+    uniqueValues = sortedVals[segStartIdx]
+    totalDurations = np.add.reduceat(sortedDurs, segStartIdx)
+    return uniqueValues, totalDurations
+
+
 class TimeseriesSet():
 
     def __init__(self, tsSetList):

--- a/src/Timeseries.py
+++ b/src/Timeseries.py
@@ -1191,11 +1191,16 @@ def sumEventArrays(startsList, endsList, valsList):
       - endTimes[i] is the next unique event time, so every duration is > 0;
       - intervals are contiguous and non-overlapping.
     """
+    # Empty edge: no input timeseries at all (np.concatenate rejects an empty list of arrays).
+    if not startsList:
+        empty = np.array([])
+        return empty, empty, empty
     # Signed event table: one +value event per interval start, one -value event per interval
     # end. np.negative allocates the negated copies (the legacy path's 'delta': -vals).
     times = np.concatenate(startsList + endsList)
     deltas = np.concatenate(valsList + list(map(np.negative, valsList)))
     if len(times) == 0:
+        # Members exist but every one is empty — still an empty sum.
         empty = np.array([])
         return empty, empty, empty
     # Global sort by event time. 'stable' keeps a deterministic order for events sharing a

--- a/src/UnitTests/test_Summaries2.py
+++ b/src/UnitTests/test_Summaries2.py
@@ -6,7 +6,8 @@ import unittest
 import numpy as np
 import pandas as pd
 import Timeseries as ts
-from Summaries2 import _makePDFRows, _buildPDFForGroupFromCache
+from Summaries2 import _makePDFRows
+from Summaries2 import _buildPDFForGroupFromCacheLegacy as _buildPDFForGroupFromCache
 
 
 def _makeSparseRLE(activeSecs: float, rateKgPerH: float) -> ts.TimeseriesRLE:

--- a/src/UnitTests/test_VectorizedSum.py
+++ b/src/UnitTests/test_VectorizedSum.py
@@ -243,21 +243,52 @@ class TestCoalesceAdjacentEqual(unittest.TestCase):
         s, e, v = _coalesceAdjacentEqual(starts, ends, values)
         self.assertEqual(len(v), 2)
 
+    def test_no_merge_across_gap(self):
+        """THE regression the KS sweep caught (issue #121): equal-valued intervals flanking a
+        GAP (removed near-zero interval / non-emitting time) must NOT merge — bridging the gap
+        stamps non-emitting time with an emission rate and corrupts the PDF. Measured on real
+        data: 293 such bridges spanned 4.5e9 seconds and shifted distributions by KS 0.11+."""
+        starts = np.array([0.0, 10.0])   # gap: [5.0, 10.0) is non-emitting
+        ends = np.array([5.0, 20.0])
+        values = np.array([2.0, 2.0])    # equal values — the old merge-on-value-alone trap
+        s, e, v = _coalesceAdjacentEqual(starts, ends, values)
+        self.assertEqual(len(v), 2)
+        np.testing.assert_array_equal(s, starts)
+        np.testing.assert_array_equal(e, ends)
+        # And duration mass at value 2.0 must be exactly 15s, never the bridged 20s.
+        self.assertAlmostEqual(float(np.sum(e - s)), 15.0, places=12)
+
+    def test_mixed_gaps_and_contiguity(self):
+        """Contiguous equal pair merges; the equal interval across a gap stays separate."""
+        starts = np.array([0.0, 5.0, 20.0])
+        ends = np.array([5.0, 10.0, 30.0])
+        values = np.array([1.0, 1.0, 1.0])
+        s, e, v = _coalesceAdjacentEqual(starts, ends, values)
+        np.testing.assert_array_equal(s, np.array([0.0, 20.0]))
+        np.testing.assert_array_equal(e, np.array([10.0, 30.0]))
+        np.testing.assert_array_equal(v, np.array([1.0, 1.0]))
+
     def test_empty(self):
         empty = np.array([])
         s, e, v = _coalesceAdjacentEqual(empty, empty, empty)
         self.assertEqual(len(v), 0)
 
     def test_duration_mass_preserved_random(self):
-        """For random already-rounded step functions: sum of durations per distinct value must
-        be identical before and after coalescing — the exact property the duration-weighted
-        PDF depends on."""
+        """For random step functions WITH GAPS: sum of durations per distinct value must be
+        identical before and after coalescing — the exact property the duration-weighted PDF
+        depends on. (The original version of this test only generated contiguous intervals,
+        which is precisely why it failed to catch the gap-bridging bug the KS sweep found.)"""
         rng = np.random.default_rng(7)
         for trial in range(25):
             n = int(rng.integers(2, 40))
-            edges = np.cumsum(rng.uniform(1.0, 10.0, size=n + 1))
-            starts = edges[:-1]
-            ends = edges[1:]
+            edges = np.cumsum(rng.uniform(1.0, 10.0, size=2 * n + 1))
+            starts = edges[0:2 * n:2]
+            ends = edges[1:2 * n + 1:2]
+            # Randomly close ~half the gaps so runs of genuinely contiguous intervals occur.
+            closeGap = rng.random(n - 1) < 0.5
+            for i in range(n - 1):
+                if closeGap[i]:
+                    starts[i + 1] = ends[i]
             values = rng.choice(np.array([0.1, 0.2, 0.3]), size=n)
             s, e, v = _coalesceAdjacentEqual(starts, ends, values)
             for distinctValue in np.unique(values):

--- a/src/UnitTests/test_VectorizedSum.py
+++ b/src/UnitTests/test_VectorizedSum.py
@@ -25,6 +25,8 @@ import pandas as pd
 import Timeseries as ts
 import Units as u
 from Summaries2 import _buildMCRunTimeseries, _coalesceAdjacentEqual, _roundedCacheArrays
+from Summaries2 import (_validateCacheBoundary, calculatePDFSummaryFromCache,
+                        _calculatePDFSummaryFromCacheLegacy)
 
 
 def makeRLE(starts, ends, values):
@@ -331,6 +333,189 @@ class TestBuildMCRunTimeseries(unittest.TestCase):
         mcRunDF = self.makeInstEmissions([('em1', 0.0, 0.0, 1.0)])
         result = _buildMCRunTimeseries(mcRunDF)
         self.assertTrue(result.isempty())
+
+
+class TestDurationWeightedDistribution(unittest.TestCase):
+    """The round-2 kernel must reproduce pandas' durations.groupby(values).sum() exactly."""
+
+    def test_matches_pandas_groupby_random(self):
+        rng = np.random.default_rng(1234)
+        for trial in range(30):
+            pieces = int(rng.integers(1, 5))
+            valsList = []
+            dursList = []
+            for _ in range(pieces):
+                n = int(rng.integers(1, 30))
+                # Draw from a small value pool so cross-piece collisions actually occur.
+                valsList.append(rng.choice(np.array([0.1, 0.5, 1.0, 2.5, 7.0]), size=n))
+                dursList.append(rng.uniform(1.0, 100.0, size=n))
+            values, durations = ts.durationWeightedDistribution(valsList, dursList)
+            refSeries = pd.Series(np.concatenate(dursList)).groupby(
+                pd.Series(np.concatenate(valsList))).sum()
+            np.testing.assert_array_equal(values, refSeries.index.to_numpy())
+            np.testing.assert_allclose(durations, refSeries.to_numpy(), rtol=1e-12)
+
+    def test_empty(self):
+        values, durations = ts.durationWeightedDistribution([], [])
+        self.assertEqual(len(values), 0)
+        values, durations = ts.durationWeightedDistribution([np.array([])], [np.array([])])
+        self.assertEqual(len(values), 0)
+
+    def test_values_strictly_ascending(self):
+        values, _ = ts.durationWeightedDistribution([np.array([3.0, 1.0, 3.0, 2.0])],
+                                                    [np.array([1.0, 1.0, 1.0, 1.0])])
+        self.assertTrue(np.all(np.diff(values) > 0))
+
+
+def makeSyntheticCache(rng, mcRuns=3, fugitiveMode='mixed'):
+    """Build a small synthetic PDF-cache frame with fine (per-facility) and coarse
+    (NaN-facility) levels, non-overlapping intervals per partition, and configurable FUGITIVE
+    presence: 'mixed' (VENTED+FUGITIVE), 'none' (VENTED only), 'only' (FUGITIVE only)."""
+    if fugitiveMode == 'mixed':
+        cats = ['VENTED', 'FUGITIVE']
+    elif fugitiveMode == 'none':
+        cats = ['VENTED']
+    else:
+        cats = ['FUGITIVE']
+    records = []
+    for mcRun in range(mcRuns):
+        for emCat in cats:
+            for level, facility in (('modelReadableName', 'F1'), ('modelReadableName', 'F2'),
+                                    ('siteTotals', None)):
+                n = int(rng.integers(1, 6))
+                edges = np.cumsum(rng.uniform(1.0, 50.0, size=n + 1))
+                for i in range(n):
+                    records.append({'facilityID': facility, 'site': 'S1', 'species': 'METHANE',
+                                    'operator': 'OP', 'psno': 'P1',
+                                    'METype': 'Sep' if level == 'modelReadableName' else '',
+                                    'unitID': 'U1' if level == 'modelReadableName' else '',
+                                    'modelReadableName': 'M1' if level == 'modelReadableName' else '',
+                                    'modelEmissionCategory': emCat, 'mcRun': mcRun,
+                                    'startTime_s': float(edges[i]), 'endTime_s': float(edges[i + 1]),
+                                    'emission_kgPerH': float(rng.uniform(0.2, 9.0)),
+                                    'cacheLevel': level})
+    return pd.DataFrame.from_records(records)
+
+
+SYNTH_GROUPINGS = [('siteTotals', ['site', 'species', 'operator', 'psno']),
+                   ('modelReadableName', ['site', 'species', 'operator', 'psno',
+                                          'METype', 'unitID', 'modelReadableName'])]
+
+
+def canonPDF(df):
+    """Canonical row order + fresh index for frame comparison (legacy concat carries
+    duplicate per-group indexes; content is what must match)."""
+    if df.empty:
+        return df.reset_index(drop=True)
+    return df.sort_values(list(df.columns)).reset_index(drop=True)
+
+
+class TestPDFFromCacheEquivalence(unittest.TestCase):
+    """The array-native calculatePDFSummaryFromCache must reproduce the retained legacy
+    implementation row-for-row: values, probabilities, cumulative probabilities, columns."""
+
+    def assertFramesMatch(self, newDF, oldDF):
+        self.assertEqual(list(newDF.columns), list(oldDF.columns))
+        self.assertEqual(len(newDF), len(oldDF))
+        new = canonPDF(newDF)
+        old = canonPDF(oldDF)
+        for col in newDF.columns:
+            if new[col].dtype.kind in ('f',):
+                np.testing.assert_allclose(new[col].to_numpy(), old[col].to_numpy(),
+                                           rtol=1e-12, atol=1e-15)
+            else:
+                # Union-filled identity columns legitimately hold NaN (a level that lacks the
+                # column) on BOTH sides; object-array NaN != NaN, so compare via sentinel fill.
+                np.testing.assert_array_equal(new[col].fillna('__nan__').to_numpy(),
+                                              old[col].fillna('__nan__').to_numpy())
+
+    def runEquivalence(self, fugitiveMode, seed):
+        rng = np.random.default_rng(seed)
+        cacheDF = makeSyntheticCache(rng, fugitiveMode=fugitiveMode)
+        totalSimSecs = 1.0e4
+        newFull, newNoFug, newStats = calculatePDFSummaryFromCache(
+            cacheDF, totalSimSecs, groupings=SYNTH_GROUPINGS)
+        oldFull, oldNoFug, oldStats = _calculatePDFSummaryFromCacheLegacy(
+            cacheDF, totalSimSecs, groupings=SYNTH_GROUPINGS)
+        self.assertFramesMatch(newFull, oldFull)
+        self.assertFramesMatch(newNoFug, oldNoFug)
+        # Stats: same groups and mcRunCounts (buildSeconds legitimately differs).
+        newS = newStats.drop(columns=['buildSeconds'])
+        oldS = oldStats.drop(columns=['buildSeconds'])
+        self.assertTrue(canonPDF(newS).equals(canonPDF(oldS)))
+
+    def test_mixed_categories(self):
+        self.runEquivalence('mixed', 11)
+
+    def test_no_fugitive_group(self):
+        """Tier 1b: without FUGITIVE, the noFugitive output equals the full output."""
+        self.runEquivalence('none', 22)
+        rng = np.random.default_rng(22)
+        cacheDF = makeSyntheticCache(rng, fugitiveMode='none')
+        full, noFug, _ = calculatePDFSummaryFromCache(cacheDF, 1.0e4, groupings=SYNTH_GROUPINGS)
+        self.assertTrue(canonPDF(full).equals(canonPDF(noFug)))
+
+    def test_fugitive_only_group(self):
+        """A FUGITIVE-only group contributes to full but NOT to noFugitive — on both paths."""
+        self.runEquivalence('only', 33)
+        rng = np.random.default_rng(33)
+        cacheDF = makeSyntheticCache(rng, fugitiveMode='only')
+        full, noFug, _ = calculatePDFSummaryFromCache(cacheDF, 1.0e4, groupings=SYNTH_GROUPINGS)
+        self.assertFalse(full.empty)
+        self.assertTrue(noFug.empty)
+
+    def test_probability_normalizes_to_active_fraction(self):
+        """The new path must preserve the probability semantics the legacy regression test
+        guards for _makePDFRows: probabilities sum to activeSecs/totalSimSecs, not 1.0."""
+        cacheDF = pd.DataFrame.from_records([
+            {'facilityID': 'F1', 'site': 'S1', 'species': 'METHANE', 'operator': 'OP',
+             'psno': 'P1', 'METype': '', 'unitID': '', 'modelReadableName': '',
+             'modelEmissionCategory': 'VENTED', 'mcRun': 0,
+             'startTime_s': 0.0, 'endTime_s': 10.0, 'emission_kgPerH': 5.0,
+             'cacheLevel': 'siteTotals'}])
+        full, _, _ = calculatePDFSummaryFromCache(
+            cacheDF, 100.0, groupings=[('siteTotals', ['site', 'species', 'operator', 'psno'])])
+        self.assertAlmostEqual(float(full['probability'].sum()), 10.0 / 100.0, places=12)
+        self.assertAlmostEqual(float(full['cumulativeProbability'].iloc[-1]), 1.0, places=12)
+
+
+class TestValidateCacheBoundary(unittest.TestCase):
+    """The single-pass validation must catch what the per-sub-group RLE constructors caught."""
+
+    @staticmethod
+    def validCache():
+        rng = np.random.default_rng(5)
+        return makeSyntheticCache(rng)
+
+    def test_valid_cache_passes(self):
+        _validateCacheBoundary(self.validCache())
+
+    def test_zero_duration_raises(self):
+        cacheDF = self.validCache()
+        cacheDF.loc[cacheDF.index[0], 'endTime_s'] = cacheDF.loc[cacheDF.index[0], 'startTime_s']
+        with self.assertRaises(ts.MalformedTimeseriesError):
+            _validateCacheBoundary(cacheDF)
+
+    def test_overlap_within_partition_raises(self):
+        cacheDF = self.validCache()
+        # Make row 0 of one partition overlap the NEXT row of the same partition.
+        firstPartition = cacheDF[(cacheDF['cacheLevel'] == 'modelReadableName')
+                                 & (cacheDF['mcRun'] == 0)
+                                 & (cacheDF['modelEmissionCategory'] == cacheDF['modelEmissionCategory'].iloc[0])
+                                 & (cacheDF['facilityID'] == 'F1')]
+        if len(firstPartition) < 2:
+            self.skipTest("synthetic partition too small to overlap")
+        idx0 = firstPartition.index[0]
+        idx1 = firstPartition.index[1]
+        cacheDF.loc[idx0, 'endTime_s'] = cacheDF.loc[idx1, 'startTime_s'] + 1.0
+        with self.assertRaises(ts.MalformedTimeseriesError):
+            _validateCacheBoundary(cacheDF)
+
+    def test_adjacent_partitions_do_not_false_positive(self):
+        """Rows of DIFFERENT partitions may 'overlap' in time freely (they are different
+        distributions); validation must group correctly, including NaN facilityID coarse rows."""
+        cacheDF = self.validCache()
+        _validateCacheBoundary(cacheDF)   # mixed fine (F1/F2) + coarse (NaN) rows share times
 
 
 if __name__ == '__main__':

--- a/src/UnitTests/test_VectorizedSum.py
+++ b/src/UnitTests/test_VectorizedSum.py
@@ -1,0 +1,337 @@
+"""Tests for the array-native summation fast path and its PDF-cascade call sites (issue #121).
+
+Covers, in order:
+  - TimeseriesSet.sum() fast path vs the retained legacy implementation (_sumLegacy), on
+    randomized interval sets and on the edge cases the legacy code encodes (shared endpoints,
+    the 1e-10 residual clip — including its deliberate drop of POSITIVE near-zero intervals,
+    empty sets, single-timeseries gaps);
+  - subclass exclusion: TimeseriesCategorical-style subclasses must never take the fast path;
+  - TimeseriesRLE.fromValidatedArrays: attribute contract vs the validating __init__;
+  - _coalesceAdjacentEqual / _roundedCacheArrays: lossless-by-construction merging (per-value
+    duration mass preserved exactly);
+  - _buildMCRunTimeseries: equivalence with a hand-built legacy sum on synthetic InstEmissions
+    rows, and preservation of the boundary validation (overlap -> MalformedTimeseriesError).
+"""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import unittest
+from unittest import mock
+
+import numpy as np
+import pandas as pd
+
+import Timeseries as ts
+import Units as u
+from Summaries2 import _buildMCRunTimeseries, _coalesceAdjacentEqual, _roundedCacheArrays
+
+
+def makeRLE(starts, ends, values):
+    """Build a TimeseriesRLE through the normal validating path, with the default colnames the
+    PDF cascade's legacy code produced (fromCollections defaults)."""
+    return ts.TimeseriesRLE.fromCollections(np.asarray(starts, dtype=float),
+                                            np.asarray(ends, dtype=float),
+                                            np.asarray(values, dtype=float))
+
+
+def makeRandomRLE(rng, tMax=1000.0, maxIntervals=8):
+    """Random non-overlapping interval set: sorted unique breakpoints carved into alternating
+    kept/skipped intervals, values well away from the 1e-10 residual-clip threshold."""
+    n = int(rng.integers(1, maxIntervals + 1))
+    breakpoints = np.sort(rng.choice(np.arange(1, int(tMax)), size=2 * n, replace=False)).astype(float)
+    starts = breakpoints[0::2]
+    ends = breakpoints[1::2]
+    values = rng.uniform(0.5, 50.0, size=n)
+    return makeRLE(starts, ends, values)
+
+
+def assertSummedEqual(testCase, fastTS, legacyTS):
+    """Assert two summed RLEs describe the same step function: identical interval edges and
+    values equal to within float-reassociation noise (~1e-16 relative; see the kernel's note —
+    addition ORDER within a shared time bucket may differ from pandas' groupby order)."""
+    fastDF, legacyDF = fastTS.df, legacyTS.df
+    testCase.assertEqual(len(fastDF), len(legacyDF))
+    if len(fastDF) == 0:
+        return
+    np.testing.assert_array_equal(fastDF[fastTS.startTimeColName].to_numpy(),
+                                  legacyDF[legacyTS.startTimeColName].to_numpy())
+    np.testing.assert_array_equal(fastDF[fastTS.endTimeColName].to_numpy(),
+                                  legacyDF[legacyTS.endTimeColName].to_numpy())
+    np.testing.assert_allclose(fastDF[fastTS.valueColName].to_numpy(),
+                               legacyDF[legacyTS.valueColName].to_numpy(),
+                               rtol=1e-12, atol=1e-13)
+
+
+class TestSumFastPathEquivalence(unittest.TestCase):
+    """The fast path must reproduce the legacy frame-based sum exactly (modulo FP
+    reassociation far below every downstream threshold)."""
+
+    def test_randomized_sets_match_legacy(self):
+        rng = np.random.default_rng(20260708)
+        for trial in range(50):
+            memberCount = int(rng.integers(1, 6))
+            members = []
+            for _ in range(memberCount):
+                members.append(makeRandomRLE(rng))
+            fast = ts.TimeseriesSet(members).sum()
+            legacy = ts.TimeseriesSet(members)._sumLegacy()
+            assertSummedEqual(self, fast, legacy)
+
+    def test_shared_endpoints_hand_case(self):
+        """Two members sharing an exact endpoint: the +/- events land in one time bucket and
+        must net, not create a zero-width interval. Hand-computed expectation."""
+        a = makeRLE([0.0, 10.0], [5.0, 20.0], [1.5, 2.5])
+        b = makeRLE([5.0], [10.0], [4.0])   # b starts exactly where a's first interval ends
+        summed = ts.TimeseriesSet([a, b]).sum()
+        legacy = ts.TimeseriesSet([a, b])._sumLegacy()
+        assertSummedEqual(self, summed, legacy)
+        np.testing.assert_array_equal(summed.df[summed.startTimeColName].to_numpy(),
+                                      np.array([0.0, 5.0, 10.0]))
+        np.testing.assert_array_equal(summed.df[summed.endTimeColName].to_numpy(),
+                                      np.array([5.0, 10.0, 20.0]))
+        np.testing.assert_allclose(summed.df[summed.valueColName].to_numpy(),
+                                   np.array([1.5, 4.0, 2.5]))
+
+    def test_exact_cancellation_clipped_to_empty(self):
+        """A member and its exact negation cancel to 0.0 everywhere; the residual clip drops
+        every interval and the result is the legacy empty frame (default column names)."""
+        a = makeRLE([0.0], [10.0], [3.0])
+        b = makeRLE([0.0], [10.0], [-3.0])
+        summed = ts.TimeseriesSet([a, b]).sum()
+        legacy = ts.TimeseriesSet([a, b])._sumLegacy()
+        self.assertTrue(summed.isempty())
+        self.assertTrue(legacy.isempty())
+        self.assertEqual(list(summed.df.columns), ['timestamp', 'nextTS', 'tsValue'])
+
+    def test_positive_near_zero_interval_dropped(self):
+        """Documents the deliberate legacy quirk the kernel preserves: the clip drops ALL
+        near-zero intervals, positive real values included — a 5e-11 emission interval
+        vanishes from the sum on BOTH paths."""
+        tiny = makeRLE([0.0], [10.0], [5e-11])
+        summed = ts.TimeseriesSet([tiny]).sum()
+        legacy = ts.TimeseriesSet([tiny])._sumLegacy()
+        self.assertTrue(summed.isempty())
+        self.assertTrue(legacy.isempty())
+
+    def test_empty_set(self):
+        summed = ts.TimeseriesSet([]).sum()
+        self.assertTrue(summed.isempty())
+        self.assertEqual(list(summed.df.columns), ['timestamp', 'nextTS', 'tsValue'])
+
+    def test_single_member_with_gap(self):
+        """One member with a gap: the sweep sees a zero-valued gap interval, the clip removes
+        it, and the output equals the input's own intervals — on both paths."""
+        a = makeRLE([0.0, 10.0], [5.0, 20.0], [2.0, 3.0])
+        summed = ts.TimeseriesSet([a]).sum()
+        legacy = ts.TimeseriesSet([a])._sumLegacy()
+        assertSummedEqual(self, summed, legacy)
+        np.testing.assert_array_equal(summed.df[summed.startTimeColName].to_numpy(),
+                                      np.array([0.0, 10.0]))
+        np.testing.assert_allclose(summed.df[summed.valueColName].to_numpy(),
+                                   np.array([2.0, 3.0]))
+
+
+class TestFastPathGating(unittest.TestCase):
+    """Only sets whose EVERY member is a plain TimeseriesRLE may take the fast path;
+    subclasses (e.g. TimeseriesCategorical state timelines, whose values are category codes)
+    must always fall back to the legacy implementation."""
+
+    def test_subclass_member_forces_legacy_path(self):
+        class SubclassedRLE(ts.TimeseriesRLE):
+            pass
+
+        a = makeRLE([0.0], [10.0], [2.0])
+        subclassed = SubclassedRLE.fromCollections(np.array([5.0]), np.array([15.0]),
+                                                   np.array([1.0]))
+        # If the fast path ran, it would call sumEventArrays — assert it never does.
+        with mock.patch.object(ts, 'sumEventArrays',
+                               side_effect=AssertionError("fast path must not run")):
+            summed = ts.TimeseriesSet([a, subclassed]).sum()
+        np.testing.assert_allclose(summed.df[summed.valueColName].to_numpy(),
+                                   np.array([2.0, 3.0, 1.0]))
+
+    def test_plain_members_use_fast_path(self):
+        a = makeRLE([0.0], [10.0], [2.0])
+        b = makeRLE([5.0], [15.0], [1.0])
+        with mock.patch.object(ts, 'sumEventArrays',
+                               wraps=ts.sumEventArrays) as kernelSpy:
+            ts.TimeseriesSet([a, b]).sum()
+        self.assertEqual(kernelSpy.call_count, 1)
+
+
+class TestFromValidatedArrays(unittest.TestCase):
+    """The trusted constructor must set everything the validating __init__ sets, and its
+    results must be full citizens (usable as members of further sums)."""
+
+    def test_attribute_contract(self):
+        starts = np.array([0.0, 5.0])
+        ends = np.array([5.0, 9.0])
+        values = np.array([1.0, 2.0])
+        rle = ts.TimeseriesRLE.fromValidatedArrays(starts, ends, values)
+        self.assertIsInstance(rle, ts.TimeseriesRLE)
+        self.assertEqual(rle.colList, [rle.startTimeColName, rle.endTimeColName, rle.valueColName])
+        self.assertTrue(rle.sorted)
+        self.assertIsNone(rle.name)
+        self.assertIsNone(rle.units)
+        self.assertFalse(rle.isempty())
+        np.testing.assert_array_equal(rle.df[rle.startTimeColName].to_numpy(), starts)
+        np.testing.assert_array_equal(rle.df[rle.endTimeColName].to_numpy(), ends)
+        np.testing.assert_array_equal(rle.df[rle.valueColName].to_numpy(), values)
+
+    def test_usable_in_subsequent_sum(self):
+        first = ts.TimeseriesSet([makeRLE([0.0], [10.0], [2.0]),
+                                  makeRLE([5.0], [15.0], [1.0])]).sum()
+        second = ts.TimeseriesSet([first, makeRLE([0.0], [15.0], [1.0])]).sum()
+        np.testing.assert_allclose(second.df[second.valueColName].to_numpy(),
+                                   np.array([3.0, 4.0, 2.0]))
+
+
+class TestSumEventArraysKernel(unittest.TestCase):
+    """Direct kernel tests, independent of the Timeseries object layer."""
+
+    def test_empty_inputs(self):
+        starts, ends, values = ts.sumEventArrays([np.array([])], [np.array([])], [np.array([])])
+        self.assertEqual(len(values), 0)
+
+    def test_hand_case(self):
+        starts, ends, values = ts.sumEventArrays(
+            [np.array([0.0, 10.0]), np.array([2.0])],
+            [np.array([5.0, 20.0]), np.array([12.0])],
+            [np.array([1.5, 2.5]), np.array([4.0])])
+        np.testing.assert_array_equal(starts, np.array([0.0, 2.0, 5.0, 10.0, 12.0]))
+        np.testing.assert_array_equal(ends, np.array([2.0, 5.0, 10.0, 12.0, 20.0]))
+        np.testing.assert_allclose(values, np.array([1.5, 5.5, 4.0, 6.5, 2.5]))
+
+    def test_output_invariants_random(self):
+        """The trusted-constructor contract: strictly increasing starts, contiguous positive-
+        duration intervals — must hold on randomized input."""
+        rng = np.random.default_rng(42)
+        for trial in range(25):
+            startsList, endsList, valsList = [], [], []
+            for _ in range(int(rng.integers(1, 5))):
+                member = makeRandomRLE(rng)
+                startsList.append(member.df[member.startTimeColName].to_numpy())
+                endsList.append(member.df[member.endTimeColName].to_numpy())
+                valsList.append(member.df[member.valueColName].to_numpy())
+            starts, ends, values = ts.sumEventArrays(startsList, endsList, valsList)
+            if len(values) == 0:
+                continue
+            self.assertTrue(np.all(np.diff(starts) > 0))
+            self.assertTrue(np.all(ends > starts))
+
+
+class TestCoalesceAdjacentEqual(unittest.TestCase):
+    """Round-then-recoalesce support: merging adjacent equal-value intervals must preserve the
+    per-value duration mass exactly (that is the losslessness argument for the PDF)."""
+
+    def test_merges_equal_runs(self):
+        starts = np.array([0.0, 5.0, 10.0, 20.0])
+        ends = np.array([5.0, 10.0, 20.0, 30.0])
+        values = np.array([1.0, 1.0, 2.0, 2.0])
+        s, e, v = _coalesceAdjacentEqual(starts, ends, values)
+        np.testing.assert_array_equal(s, np.array([0.0, 10.0]))
+        np.testing.assert_array_equal(e, np.array([10.0, 30.0]))
+        np.testing.assert_array_equal(v, np.array([1.0, 2.0]))
+
+    def test_no_merge_when_values_differ(self):
+        starts = np.array([0.0, 5.0])
+        ends = np.array([5.0, 10.0])
+        values = np.array([1.0, 2.0])
+        s, e, v = _coalesceAdjacentEqual(starts, ends, values)
+        self.assertEqual(len(v), 2)
+
+    def test_empty(self):
+        empty = np.array([])
+        s, e, v = _coalesceAdjacentEqual(empty, empty, empty)
+        self.assertEqual(len(v), 0)
+
+    def test_duration_mass_preserved_random(self):
+        """For random already-rounded step functions: sum of durations per distinct value must
+        be identical before and after coalescing — the exact property the duration-weighted
+        PDF depends on."""
+        rng = np.random.default_rng(7)
+        for trial in range(25):
+            n = int(rng.integers(2, 40))
+            edges = np.cumsum(rng.uniform(1.0, 10.0, size=n + 1))
+            starts = edges[:-1]
+            ends = edges[1:]
+            values = rng.choice(np.array([0.1, 0.2, 0.3]), size=n)
+            s, e, v = _coalesceAdjacentEqual(starts, ends, values)
+            for distinctValue in np.unique(values):
+                before = float(np.sum((ends - starts)[values == distinctValue]))
+                after = float(np.sum((e - s)[v == distinctValue]))
+                self.assertAlmostEqual(before, after, places=9)
+
+    def test_rounded_cache_arrays_composition(self):
+        """_roundedCacheArrays: rounding collapses near-equal rates, then coalescing merges the
+        now-equal neighbours; with coalesce off every interval survives (legacy behaviour)."""
+        starts = np.array([0.0, 5.0, 10.0])
+        ends = np.array([5.0, 10.0, 15.0])
+        values = np.array([1.0000001, 0.9999999, 2.0])
+        sOff, eOff, vOff = _roundedCacheArrays(starts, ends, values, 1e-3, False)
+        self.assertEqual(len(vOff), 3)
+        np.testing.assert_allclose(vOff[:2], np.array([1.0, 1.0]))
+        sOn, eOn, vOn = _roundedCacheArrays(starts, ends, values, 1e-3, True)
+        np.testing.assert_array_equal(sOn, np.array([0.0, 10.0]))
+        np.testing.assert_array_equal(eOn, np.array([10.0, 15.0]))
+        np.testing.assert_allclose(vOn, np.array([1.0, 2.0]))
+
+
+class TestBuildMCRunTimeseries(unittest.TestCase):
+    """The InstEmissions-boundary call site: array path must match a hand-built legacy sum and
+    must preserve the boundary validation the TimeseriesRLE constructor used to provide."""
+
+    @staticmethod
+    def makeInstEmissions(rowsList):
+        """rowsList: (emitterID, timestamp_s, duration_s, emission_kgPerS) tuples."""
+        records = []
+        for emitterID, timestamp, duration, rate in rowsList:
+            records.append({'emitterID': emitterID, 'timestamp_s': timestamp,
+                            'duration_s': duration, 'emission_kgPerS': rate,
+                            'site': 'TestSite', 'mcRun': 0})
+        return pd.DataFrame.from_records(records)
+
+    def test_matches_legacy_sum(self):
+        mcRunDF = self.makeInstEmissions([
+            ('em1', 0.0, 5.0, 1.0),
+            ('em1', 10.0, 10.0, 2.0),
+            ('em2', 2.0, 10.0, 4.0),
+        ])
+        result = _buildMCRunTimeseries(mcRunDF)
+        # Hand-built legacy equivalent: per-emitter RLEs summed via the retained legacy path.
+        legacyMembers = [
+            makeRLE([0.0, 10.0], [5.0, 20.0], [1.0 * u.SECONDS_PER_HOUR, 2.0 * u.SECONDS_PER_HOUR]),
+            makeRLE([2.0], [12.0], [4.0 * u.SECONDS_PER_HOUR]),
+        ]
+        legacy = ts.TimeseriesSet(legacyMembers)._sumLegacy()
+        assertSummedEqual(self, result, legacy)
+
+    def test_zero_duration_rows_filtered(self):
+        mcRunDF = self.makeInstEmissions([
+            ('em1', 0.0, 5.0, 1.0),
+            ('em1', 5.0, 0.0, 9.9),   # zero-duration: filtered with a warning, not an error
+        ])
+        result = _buildMCRunTimeseries(mcRunDF)
+        self.assertEqual(len(result.df), 1)
+        np.testing.assert_allclose(result.df[result.valueColName].to_numpy(),
+                                   np.array([1.0 * u.SECONDS_PER_HOUR]))
+
+    def test_overlap_raises_malformed(self):
+        """Overlapping rows for one emitter (as ordered) are malformed input — the same
+        MalformedTimeseriesError the TimeseriesRLE constructor raised on this data."""
+        mcRunDF = self.makeInstEmissions([
+            ('em1', 0.0, 10.0, 1.0),
+            ('em1', 5.0, 10.0, 2.0),   # starts before the previous row ends
+        ])
+        with self.assertRaises(ts.MalformedTimeseriesError):
+            _buildMCRunTimeseries(mcRunDF)
+
+    def test_empty_after_filter_returns_empty(self):
+        mcRunDF = self.makeInstEmissions([('em1', 0.0, 0.0, 1.0)])
+        result = _buildMCRunTimeseries(mcRunDF)
+        self.assertTrue(result.isempty())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
> **⚠ MERGE HOLD — review welcome now, merge blocked on the #47 base-branch question.**
> This branch is based at `c059d25` — the last runnable `Site_Definition_Cleanup` commit. The
> current S_D_C tip (`8e1b77e`, the PV_MAES_UncertaintyPaper merge) cannot run: the model
> classes require distribution parameters (e.g. `tankOverpressurePLeakDist`) the bundled input
> curation does not supply, so `instantiateIntake` raises on every site. Merging this PR onto
> the current tip would land the work on a branch that still cannot run. Recommended sequence:
> resolve #47 on S_D_C first (revert of `8e1b77e` restores `c059d25`'s tree exactly), then merge.

Implements #121 (both rounds) plus the #70-follow-up/#120 config gates. All changes are serial,
in-workitem — the one-process-per-workitem execution model is unchanged.

## Commits

```
43cd3d0  fix(pdf): coalesce only CONTIGUOUS equal-value intervals — gap bridging corrupted PDFs
cf25f39  perf(pdf): array-native PDF/CDF construction stage (#121 round 2)
fe25108  perf(pdf): share identity-string objects in cache-frame materialisation
a23287f  test(timeseries): equivalence + boundary tests for the vectorized sum path (#121)
00be2c5  perf(pdf): array-native summation + one-frame store accumulation in the cache build (#121)
6276c08  perf(timeseries): array-native sum kernel + trusted constructor + sum() fast path (#121)
4b59568  feat(pdf): pdfCoalesce + pdfSpecies config gates for the PDF cascade
```

4 files, +1,152/−43: `Timeseries.py`, `Summaries2.py`, `UnitTests/test_VectorizedSum.py` (new,
36 tests), `UnitTests/test_Summaries2.py` (one import updated to the retained legacy name).

## What it does

- **Vectorization** (#121): the signed-event summation sweep and the duration-weighted PDF/CDF
  construction now run on raw numpy arrays (argsort + reduceat), with trusted constructors for
  kernel outputs whose invariants hold by construction. Legacy implementations are retained
  verbatim (`_sumLegacy`, `_buildPDFForGroupFromCacheLegacy`, `_calculatePDFSummaryFromCacheLegacy`)
  as fallbacks and as the reference implementations the equivalence tests compare against.
  Validation is preserved at every system boundary (raw InstEmissions; parquet-loaded caches via
  a single vectorized `_validateCacheBoundary` pass); `TimeseriesCategorical` state timelines are
  type-gated onto the legacy path.
- **`pdfCoalesce`** (default off): merges consecutive equal-rate, CONTIGUOUS intervals in the
  cache. −89.9% cache rows on the dominant site, measured KS 0.000000 vs the unmodified engine
  across all 2,482 distributions. (The contiguity condition is load-bearing — see `43cd3d0`.)
- **`pdfSpecies`** (default off): restricts the PDF cascade to listed species values (#120).
  Measured 0.21× time and rows with a 3-species list; other summaries unaffected.

## Verification

- 143 unit tests pass (36 new), existing suites unchanged.
- Real-data gates on the 5-site mc=100 workload: PDFCache (60,497 rows) and PDF (35,177 rows)
  datasets **row-identical** to the pre-change engine; persisted parquet **byte-identical** with
  gates off.
- Full measurement history, including two mid-course corrections caught by the test
  harness (coalesce gap-bridging; a +26% RSS regression), is on #121.

## Measured performance (`-w 8`, stored mc=100, 5 sites, PDF phases via recalc)

| | before | after |
|---|---:|---:|
| PDF-phase wall | 42.9 min | **11.7 min (3.68×)** |
| dominant-site cache build | ~2,900 s | **~640 s (4.5×)** |
| peak RSS | 3,658 MB | **2,990 MB (−18%)** |
| worker scaling | — | flat for w ≥ 5 (= site count), measured w ∈ {2,5,8} |

Related: #113 (origin of the perf investigation), #119, #120, #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
